### PR TITLE
Change to the regex to better support apostrophes in names.

### DIFF
--- a/lib/bolognese/string.rb
+++ b/lib/bolognese/string.rb
@@ -1,5 +1,6 @@
 class String
   def my_titleize
-    self.gsub(/(\b[\w']+\b|_)(.)/) { "#{$1}#{$2.upcase}" }
+    #self.gsub(/(\b[\w']+\b|_)(.)/) { "#{$1}#{$2.upcase}" }
+    self.gsub(/\b(['’]?[a-z])/) { "#{$1.capitalize}" }
   end
 end

--- a/lib/bolognese/string.rb
+++ b/lib/bolognese/string.rb
@@ -1,5 +1,5 @@
 class String
   def my_titleize
-    self.gsub(/(\b|_)(.)/) { "#{$1}#{$2.upcase}" }
+    self.gsub(/(\b[\w']+\b|_)(.)/) { "#{$1}#{$2.upcase}" }
   end
 end


### PR DESCRIPTION
Originally \b is just a word boundary that doesnt include apostrophes.
I've extended this to capture an initial boundary that is all word characters and apostrophes.