### PR TITLE
csl-json: fix date parts label for empty date

### DIFF
--- a/lib/bolognese/utils.rb
+++ b/lib/bolognese/utils.rb
@@ -640,7 +640,7 @@ module Bolognese
     end
 
     def get_date_parts(iso8601_time)
-      return { "date_parts" => [[]] } if iso8601_time.nil?
+      return { 'date-parts' => [[]] } if iso8601_time.nil?
 
       year = iso8601_time[0..3].to_i
       month = iso8601_time[5..6].to_i


### PR DESCRIPTION
- Fix the property name of the date parts when the date is empty. It should be `date-parts`, not `date_parts`.

- Change to single quotes, to match other, similar code.

I don't have the environment to test this right now, but it seems like a simple enough change.