### PR TITLE
Default to `ScholarlyArticle` type for `citation` and `isBasedOn` relationships with datasets

### DIFF
--- a/lib/bolognese/metadata_utils.rb
+++ b/lib/bolognese/metadata_utils.rb
@@ -103,7 +103,7 @@ module Bolognese
         end.unwrap,
         "isBasedOn" => Array.wrap(related_identifiers).select { |ri| ri["relationType"] == "IsSupplementTo" }.map do |r| 
           { "@id" => normalize_doi(r["relatedIdentifier"]),
-            "@type" => r["resourceTypeGeneral"] || "ScholarlyArticle", 
+            "@type" => r["resourceTypeGeneral"] || "ScholarlyArticle",
             "identifier" => r["relatedIdentifierType"] == "DOI" ? nil : to_identifier(r) }.compact
         end.unwrap }.compact
     end

--- a/lib/bolognese/metadata_utils.rb
+++ b/lib/bolognese/metadata_utils.rb
@@ -98,7 +98,7 @@ module Bolognese
     def reverse
       { "citation" => Array.wrap(related_identifiers).select { |ri| ri["relationType"] == "IsReferencedBy" }.map do |r| 
         { "@id" => normalize_doi(r["relatedIdentifier"]),
-          "@type" => r["resourceTypeGeneral"] || "CreativeWork",
+          "@type" => r["resourceTypeGeneral"] || "ScholarlyArticle",
           "identifier" => r["relatedIdentifierType"] == "DOI" ? nil : to_identifier(r) }.compact
         end.unwrap,
         "isBasedOn" => Array.wrap(related_identifiers).select { |ri| ri["relationType"] == "IsSupplementTo" }.map do |r| 

--- a/lib/bolognese/metadata_utils.rb
+++ b/lib/bolognese/metadata_utils.rb
@@ -103,7 +103,7 @@ module Bolognese
         end.unwrap,
         "isBasedOn" => Array.wrap(related_identifiers).select { |ri| ri["relationType"] == "IsSupplementTo" }.map do |r| 
           { "@id" => normalize_doi(r["relatedIdentifier"]),
-            "@type" => r["resourceTypeGeneral"] || "CreativeWork",
+            "@type" => r["resourceTypeGeneral"] || "ScholarlyArticle",
             "identifier" => r["relatedIdentifierType"] == "DOI" ? nil : to_identifier(r) }.compact
         end.unwrap }.compact
     end

--- a/lib/bolognese/metadata_utils.rb
+++ b/lib/bolognese/metadata_utils.rb
@@ -103,7 +103,7 @@ module Bolognese
         end.unwrap,
         "isBasedOn" => Array.wrap(related_identifiers).select { |ri| ri["relationType"] == "IsSupplementTo" }.map do |r| 
           { "@id" => normalize_doi(r["relatedIdentifier"]),
-            "@type" => r["resourceTypeGeneral"] || "ScholarlyArticle",
+            "@type" => r["resourceTypeGeneral"] || "ScholarlyArticle", 
             "identifier" => r["relatedIdentifierType"] == "DOI" ? nil : to_identifier(r) }.compact
         end.unwrap }.compact
     end

--- a/spec/writers/schema_org_writer_spec.rb
+++ b/spec/writers/schema_org_writer_spec.rb
@@ -48,7 +48,7 @@ describe Bolognese::Metadata, vcr: true do
       subject = Bolognese::Metadata.new(input: input, from: "datacite")
       json = JSON.parse(subject.schema_org)
       expect(json["@id"]).to eq("https://doi.org/10.5061/dryad.8515")
-      expect(json["@reverse"]).to eq("citation" => [{"@id"=>"https://doi.org/10.1371/journal.ppat.1000446", "@type"=>"CreativeWork"}, {"@type"=>"CreativeWork", "identifier"=>{"@type"=>"PropertyValue", "propertyID"=>"PMID", "value"=>"19478877"}}],
+      expect(json["@reverse"]).to eq("citation" => [{"@id"=>"https://doi.org/10.1371/journal.ppat.1000446", "@type"=>"ScholarlyArticle"}, {"@type"=>"ScholarlyArticle", "identifier"=>{"@type"=>"PropertyValue", "propertyID"=>"PMID", "value"=>"19478877"}}],
         "isBasedOn" => [{"@id"=>"https://doi.org/10.1371/journal.ppat.1000446", "@type"=>"ScholarlyArticle"}, {"@type"=>"ScholarlyArticle", "identifier"=>{"@type"=>"PropertyValue", "propertyID"=>"PMID", "value"=>"19478877"}}])
     end
 

--- a/spec/writers/schema_org_writer_spec.rb
+++ b/spec/writers/schema_org_writer_spec.rb
@@ -49,7 +49,7 @@ describe Bolognese::Metadata, vcr: true do
       json = JSON.parse(subject.schema_org)
       expect(json["@id"]).to eq("https://doi.org/10.5061/dryad.8515")
       expect(json["@reverse"]).to eq("citation" => [{"@id"=>"https://doi.org/10.1371/journal.ppat.1000446", "@type"=>"CreativeWork"}, {"@type"=>"CreativeWork", "identifier"=>{"@type"=>"PropertyValue", "propertyID"=>"PMID", "value"=>"19478877"}}],
-        "isBasedOn" => [{"@id"=>"https://doi.org/10.1371/journal.ppat.1000446", "@type"=>"CreativeWork"}, {"@type"=>"CreativeWork", "identifier"=>{"@type"=>"PropertyValue", "propertyID"=>"PMID", "value"=>"19478877"}}])
+        "isBasedOn" => [{"@id"=>"https://doi.org/10.1371/journal.ppat.1000446", "@type"=>"ScholarlyArticle"}, {"@type"=>"ScholarlyArticle", "identifier"=>{"@type"=>"PropertyValue", "propertyID"=>"PMID", "value"=>"19478877"}}])
     end
 
     it "Schema.org JSON IsSupplementTo" do
@@ -57,7 +57,7 @@ describe Bolognese::Metadata, vcr: true do
       subject = Bolognese::Metadata.new(input: input, from: "datacite")
       json = JSON.parse(subject.schema_org)
       expect(json["@id"]).to eq("https://doi.org/10.5517/cc8h01s")
-      expect(json["@reverse"]).to eq("isBasedOn"=>{"@id"=>"https://doi.org/10.1107/s1600536804021154", "@type"=>"CreativeWork"})
+      expect(json["@reverse"]).to eq("isBasedOn"=>{"@id"=>"https://doi.org/10.1107/s1600536804021154", "@type"=>"ScholarlyArticle"})
     end
 
     it "rdataone" do
@@ -132,7 +132,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(json["contentSize"]).to eq("15.7M")
       expect(json["contentUrl"]).to eq("https://storage.googleapis.com/gtex_analysis_v7/single_tissue_eqtl_data/GTEx_Analysis_v7_eQTL_expression_matrices.tar.gz")
       expect(json["includedInDataCatalog"]).to eq("@id"=>"https://www.ebi.ac.uk/miriam/main/datatypes/MIR:00000663", "@type"=>"DataCatalog", "name"=>"GTEx")
-      expect(json["@reverse"]).to eq("isBasedOn"=>{"@id"=>"https://doi.org/10.1038/nmeth.4407", "@type"=>"CreativeWork"})
+      expect(json["@reverse"]).to eq("isBasedOn"=>{"@id"=>"https://doi.org/10.1038/nmeth.4407", "@type"=>"ScholarlyArticle"})
     end
 
     it "series information" do

--- a/spec/writers/turtle_writer_spec.rb
+++ b/spec/writers/turtle_writer_spec.rb
@@ -18,7 +18,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.valid?).to be true
       ttl = subject.turtle.split("\n")
       expect(ttl[0]).to eq("@prefix schema: <http://schema.org/> .")
-      expect(ttl[2]).to eq("<https://doi.org/10.1371/journal.ppat.1000446> a schema:CreativeWork;")
+      expect(ttl[2]).to eq("<https://doi.org/10.1371/journal.ppat.1000446> a schema:ScholarlyArticle;")
     end
 
     # it "BlogPosting" do


### PR DESCRIPTION
This PR implements changes discussed in https://github.com/schemaorg/schemaorg/issues/1763 making relationships between scholarly articles and datasets more explicit.