### PR TITLE
Don't try and normalise "Other" funder types.

### DIFF
--- a/lib/bolognese/readers/datacite_reader.rb
+++ b/lib/bolognese/readers/datacite_reader.rb
@@ -93,7 +93,7 @@ module Bolognese
           "bibtex" => Bolognese::Utils::CR_TO_BIB_TRANSLATIONS[resource_type.to_s.underscore.camelcase] || Bolognese::Utils::SO_TO_BIB_TRANSLATIONS[schema_org] || "misc",
           "ris" => Bolognese::Utils::CR_TO_RIS_TRANSLATIONS[resource_type.to_s.underscore.camelcase] || Bolognese::Utils::DC_TO_RIS_TRANSLATIONS[resource_type_general.to_s.dasherize] || "GEN"
         }.compact
-        
+
         titles = Array.wrap(meta.dig("titles", "title")).map do |r|
           if r.blank?
             nil
@@ -164,12 +164,15 @@ module Bolognese
         funding_references = Array.wrap(meta.dig("fundingReferences", "fundingReference")).compact.map do |fr|
           scheme_uri = parse_attributes(fr["funderIdentifier"], content: "schemeURI")
           funder_identifier = parse_attributes(fr["funderIdentifier"])
-          funder_identifier = !funder_identifier.to_s.start_with?("https://","http://") && scheme_uri.present? ? normalize_id(scheme_uri + funder_identifier) : normalize_id(funder_identifier)
-          
+          funder_identifier_type = parse_attributes(fr["funderIdentifier"], content: "funderIdentifierType")
+          if funder_identifier_type != "Other"
+            funder_identifier = !funder_identifier.to_s.start_with?("https://","http://") && scheme_uri.present? ? normalize_id(scheme_uri + funder_identifier) : normalize_id(funder_identifier)
+          end
+
           {
             "funderName" => fr["funderName"],
             "funderIdentifier" => funder_identifier,
-            "funderIdentifierType" => parse_attributes(fr["funderIdentifier"], content: "funderIdentifierType"),
+            "funderIdentifierType" => funder_identifier_type,
             "awardNumber" => parse_attributes(fr["awardNumber"]),
             "awardUri" => parse_attributes(fr["awardNumber"], content: "awardURI"),
             "awardTitle" => fr["awardTitle"] }.compact
@@ -181,7 +184,7 @@ module Bolognese
             rid = ri["__content__"]
           end
 
-          { 
+          {
             "relatedIdentifier" => rid,
             "relatedIdentifierType" => ri["relatedIdentifierType"],
             "relationType" => ri["relationType"],

--- a/spec/fixtures/datacite-funderIdentifier.xml
+++ b/spec/fixtures/datacite-funderIdentifier.xml
@@ -52,6 +52,10 @@
       <funderIdentifier funderIdentifierType="ISNI" schemeURI="http://www.isni.org/isni/">http://www.isni.org/isni/0000000119587073</funderIdentifier>
     </fundingReference>
     <fundingReference>
+      <funderName>Acme Inc</funderName>
+      <funderIdentifier funderIdentifierType="Other">1234</funderIdentifier>
+    </fundingReference>
+    <fundingReference>
       <funderName>European Commission</funderName>
       <funderIdentifier funderIdentifierType="Crossref Funder ID" schemeURI="https://doi.org/">https://doi.org/10.13039/501100000780</funderIdentifier>
     </fundingReference>

--- a/spec/readers/datacite_reader_spec.rb
+++ b/spec/readers/datacite_reader_spec.rb
@@ -254,7 +254,7 @@ describe Bolognese::Metadata, vcr: true do
           "funderIdentifierType"=>"Crossref Funder ID",
           "funderName"=>"European Commission"}],
         types: { "resourceTypeGeneral" => "Dataset", "schemaOrg" => "Dataset" })
-      
+
       expect(subject.valid?).to be true
       expect(subject.doi).to eq("10.5281/zenodo.1239")
       expect(subject.identifiers).to eq([{"identifier"=>"https://doi.org/10.5281/zenodo.1239", "identifierType"=>"DOI"}])
@@ -308,6 +308,10 @@ describe Bolognese::Metadata, vcr: true do
         "funderIdentifier"=>"https://doi.org/10.13039/501100000780",
         "funderIdentifierType"=>"Crossref Funder ID",
         "funderName"=>"European Commission"})
+      expect(subject.funding_references[1]).to eq({
+          "funderIdentifier"=>"1234",
+          "funderIdentifierType"=>"Other",
+          "funderName"=>"Acme Inc"})
     end
 
     it "geo_location empty" do


### PR DESCRIPTION
There was a normalisation happening trying to ensure "http/https" or a DOI on everything under funderIdentifiers, but Other type can be anything according to schema.
Related to bug: #84

## Purpose
Proposal here is to ensure we dont try and do normalisation for "Other", which has no specified structure.

## Approach
By doing a simple check on funder identifier type

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A