### PR TITLE
fix: add language support for reading

### DIFF
--- a/lib/bolognese/readers/schema_org_reader.rb
+++ b/lib/bolognese/readers/schema_org_reader.rb
@@ -128,6 +128,13 @@ module Bolognese
         dates << { "date" => meta.fetch("dateModified"), "dateType" => "Updated" } if Date.edtf(meta.fetch("dateModified", nil)).present?
         publication_year = meta.fetch("datePublished")[0..3] if meta.fetch("datePublished", nil).present?
 
+        case true
+        when meta.fetch("inLanguage", nil).is_a?(String)
+          language = meta.fetch("inLanguage", nil)
+        when meta.fetch("inLanguage", nil).is_a?(Object)
+          language = meta.dig("inLanguage", 'alternateName') || meta.dig("inLanguage", 'name')
+        end
+
         state = meta.present? || read_options.present? ? "findable" : "not_found"
         geo_locations = Array.wrap(meta.fetch("spatialCoverage", nil)).map do |gl|
           if gl.dig("geo", "box")
@@ -136,7 +143,7 @@ module Bolognese
               "westBoundLongitude" => w,
               "eastBoundLongitude" => e,
               "southBoundLatitude" => s,
-              "northBoundLatitude" => n
+              "northBoundLatitude" => n,
             }.compact.presence
           else
             geo_location_box = nil
@@ -179,6 +186,7 @@ module Bolognese
           "rights_list" => rights_list,
           "version_info" => meta.fetch("version", nil).to_s.presence,
           "subjects" => subjects,
+          "language" => language.to_s.presence,
           "state" => state,
           "schema_version" => meta.fetch("schemaVersion", nil).to_s.presence,
           "funding_references" => funding_references,

--- a/spec/fixtures/schema_org.json
+++ b/spec/fixtures/schema_org.json
@@ -24,6 +24,11 @@
     "description": "Eating your own dog food is a slang term to describe that an organization should itself use the products and services it provides. For DataCite this means that we should use DOIs with appropriate metadata and strategies for long-term preservation for...",
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "image": "https://blog.datacite.org/images/2016/12/230785.jpg",
+    "inLanguage": {
+        "@type": "Language",
+        "alternateName": "en",
+        "name": "English"
+    },
     "encoding": {
         "@type": "MediaObject",
         "@id": "https://blog.datacite.org/eating-your-own-dog-food/eating-your-own-dog-food.xml",

--- a/spec/readers/schema_org_reader_spec.rb
+++ b/spec/readers/schema_org_reader_spec.rb
@@ -66,6 +66,8 @@ describe Bolognese::Metadata, vcr: true do
       input = "https://www.zenodo.org/record/1196821"
       subject = Bolognese::Metadata.new(input: input, from: "schema_org")
       expect(subject.valid?).to be false
+
+      expect(subject.language).to eq("eng")
       expect(subject.errors).to eq("49:0: ERROR: Element '{http://datacite.org/schema/kernel-4}publisher': [facet 'minLength'] The value has a length of '0'; this underruns the allowed minimum length of '1'.")
       expect(subject.identifiers).to eq([{"identifier"=>"https://doi.org/10.5281/zenodo.1196821", "identifierType"=>"DOI"}])
       expect(subject.doi).to eq("10.5281/zenodo.1196821")
@@ -154,6 +156,7 @@ describe Bolognese::Metadata, vcr: true do
       input = fixture_path + 'schema_org.json'
       subject = Bolognese::Metadata.new(input: input)
       expect(subject.valid?).to be true
+      expect(subject.language).to eq("en")
       expect(subject.identifiers).to eq([{"identifier"=>"https://doi.org/10.5438/4k3m-nyvg", "identifierType"=>"DOI"}])
       expect(subject.url).to eq("https://blog.datacite.org/eating-your-own-dog-food")
       expect(subject.types).to eq("bibtex"=>"article", "citeproc"=>"post-weblog", "resourceTypeGeneral"=>"Text", "ris"=>"GEN", "schemaOrg"=>"BlogPosting")
@@ -247,6 +250,7 @@ describe Bolognese::Metadata, vcr: true do
       subject = Bolognese::Metadata.new(input: input)
 
       expect(subject.valid?).to be true
+      expect(subject.language).to eq("en")
       expect(subject.identifiers).to eq([{"identifier"=>"https://doi.org/10.1594/pangaea.842237", "identifierType"=>"DOI"}])
       expect(subject.types).to eq("bibtex"=>"misc", "citeproc"=>"dataset", "resourceTypeGeneral"=>"Dataset", "ris"=>"DATA", "schemaOrg"=>"Dataset")
       expect(subject.creators.length).to eq(2)


### PR DESCRIPTION
## Purpose

adds support for reading inLanguge in schema.org

closes: https://github.com/datacite/bolognese/issues/87

## Approach

Accepts every language type that can be set


#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

## Learning
<!--- _Describe the research stage_ -->

inlanguage it can be  language object or a text https://webschemas.org/inLanguage

## Status
- [x] Ready for Review

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
