### PR TITLE
Add support for multiple geolocation polygons

### DIFF
--- a/lib/bolognese/readers/datacite_reader.rb
+++ b/lib/bolognese/readers/datacite_reader.rb
@@ -240,7 +240,6 @@ module Bolognese
               "geoLocationPolygon" => Array.wrap(gl.dig("geoLocationPolygon")).map do |glp|
                 Array.wrap(glp.dig("polygonPoint")).map { |glpp| { "polygonPoint" => glpp } }.compact.presence
               end,
-              # "geoLocationPolygon" => Array.wrap(gl.dig("geoLocationPolygon", "polygonPoint")).map { |glp| { "polygonPoint" => glp } }.compact.presence,
               "geoLocationPlace" => parse_attributes(gl["geoLocationPlace"], first: true).to_s.strip.presence
             }.compact
           end

--- a/lib/bolognese/readers/datacite_reader.rb
+++ b/lib/bolognese/readers/datacite_reader.rb
@@ -237,7 +237,10 @@ module Bolognese
                 "southBoundLatitude" => gl.dig("geoLocationBox", "southBoundLatitude"),
                 "northBoundLatitude" => gl.dig("geoLocationBox", "northBoundLatitude")
               }.compact.presence,
-              "geoLocationPolygon" => Array.wrap(gl.dig("geoLocationPolygon", "polygonPoint")).map { |glp| { "polygonPoint" => glp } }.compact.presence,
+              "geoLocationPolygon" => Array.wrap(gl.dig("geoLocationPolygon")).map do |glp|
+                Array.wrap(glp.dig("polygonPoint")).map { |glpp| { "polygonPoint" => glpp } }.compact.presence
+              end,
+              # "geoLocationPolygon" => Array.wrap(gl.dig("geoLocationPolygon", "polygonPoint")).map { |glp| { "polygonPoint" => glp } }.compact.presence,
               "geoLocationPlace" => parse_attributes(gl["geoLocationPlace"], first: true).to_s.strip.presence
             }.compact
           end

--- a/spec/fixtures/datacite-geolocationpolygons-multiple.xml
+++ b/spec/fixtures/datacite-geolocationpolygons-multiple.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.4/metadata.xsd">
+<identifier identifierType="DOI">10.5072/multiplegeopolygons</identifier>
+    <creators>
+        <creator>
+            <creatorName>John Smithy</creatorName>
+        </creator>
+    </creators>
+    <titles>
+        <title>Multiple Geopolygon testing</title>
+    </titles>
+    <resourceType resourceTypeGeneral="Software">XML</resourceType>
+    <publisher>DataCite</publisher>
+    <publicationYear>2021</publicationYear>
+    <geoLocations>
+    <geoLocation>
+      <geoLocationPolygon>
+        <polygonPoint>
+          <pointLongitude>41</pointLongitude>
+          <pointLatitude>71</pointLatitude>
+        </polygonPoint>
+        <polygonPoint>
+          <pointLongitude>45</pointLongitude>
+          <pointLatitude>75</pointLatitude>
+        </polygonPoint>
+        <polygonPoint>
+          <pointLongitude>55</pointLongitude>
+          <pointLatitude>85</pointLatitude>
+        </polygonPoint>
+        <polygonPoint>
+          <pointLongitude>41</pointLongitude>
+          <pointLatitude>71</pointLatitude>
+        </polygonPoint>
+      </geoLocationPolygon>
+      <geoLocationPolygon>
+        <polygonPoint>
+          <pointLongitude>65</pointLongitude>
+          <pointLatitude>80</pointLatitude>
+        </polygonPoint>
+        <polygonPoint>
+          <pointLongitude>55</pointLongitude>
+          <pointLatitude>75</pointLatitude>
+        </polygonPoint>
+        <polygonPoint>
+          <pointLongitude>45</pointLongitude>
+          <pointLatitude>73</pointLatitude>
+        </polygonPoint>
+        <polygonPoint>
+          <pointLongitude>65</pointLongitude>
+          <pointLatitude>80</pointLatitude>
+        </polygonPoint>
+      </geoLocationPolygon>
+    </geoLocation>
+  </geoLocations>
+</resource>

--- a/spec/readers/datacite_reader_spec.rb
+++ b/spec/readers/datacite_reader_spec.rb
@@ -1545,4 +1545,26 @@ describe Bolognese::Metadata, vcr: true do
     expect(subject.formats.first).to eq("application/xml")
   end
 
+  it "Parsing multiple geolocationpolygon elements" do
+    input = fixture_path + "datacite-geolocationpolygons-multiple.xml"
+    subject = Bolognese::Metadata.new(input: input)
+    expect(subject.valid?).to be true
+    expect(subject.id).to eq("https://doi.org/10.5072/multiplegeopolygons")
+    expect(subject.geo_locations).to eq([
+      { "geoLocationPolygon"=> [
+        [ {"polygonPoint"=>{"pointLatitude"=>"71", "pointLongitude"=>"41"}},
+          {"polygonPoint"=>{"pointLatitude"=>"75", "pointLongitude"=>"45"}},
+          {"polygonPoint"=>{"pointLatitude"=>"85", "pointLongitude"=>"55"}},
+          {"polygonPoint"=>{"pointLatitude"=>"71", "pointLongitude"=>"41"}}],
+        [
+          {"polygonPoint"=>{"pointLatitude"=>"80", "pointLongitude"=>"65"}},
+          {"polygonPoint"=>{"pointLatitude"=>"75", "pointLongitude"=>"55"}},
+          {"polygonPoint"=>{"pointLatitude"=>"73", "pointLongitude"=>"45"}},
+          {"polygonPoint"=>{"pointLatitude"=>"80", "pointLongitude"=>"65"}}
+        ]
+      ] }
+      ]
+    )
+  end
+
 end


### PR DESCRIPTION
This is to match what is supported in datacite metadata.

## Purpose
Before geolocation polygons did not get mapped correctly to an array.

closes: #68


## Approach
Wrap polygons in an array.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
