### PR TITLE
Support returning single geoLocationPolygon

### DIFF
--- a/spec/fixtures/datacite-geolocationpolygons-multiple.xml
+++ b/spec/fixtures/datacite-geolocationpolygons-multiple.xml
@@ -52,5 +52,25 @@
         </polygonPoint>
       </geoLocationPolygon>
     </geoLocation>
+    <geoLocation>
+      <geoLocationPolygon>
+        <polygonPoint>
+          <pointLongitude>65</pointLongitude>
+          <pointLatitude>80</pointLatitude>
+        </polygonPoint>
+        <polygonPoint>
+          <pointLongitude>55</pointLongitude>
+          <pointLatitude>75</pointLatitude>
+        </polygonPoint>
+        <polygonPoint>
+          <pointLongitude>45</pointLongitude>
+          <pointLatitude>73</pointLatitude>
+        </polygonPoint>
+        <polygonPoint>
+          <pointLongitude>65</pointLongitude>
+          <pointLatitude>80</pointLatitude>
+        </polygonPoint>
+      </geoLocationPolygon>
+    </geoLocation>
   </geoLocations>
 </resource>

--- a/spec/readers/datacite_reader_spec.rb
+++ b/spec/readers/datacite_reader_spec.rb
@@ -1562,7 +1562,15 @@ describe Bolognese::Metadata, vcr: true do
           {"polygonPoint"=>{"pointLatitude"=>"73", "pointLongitude"=>"45"}},
           {"polygonPoint"=>{"pointLatitude"=>"80", "pointLongitude"=>"65"}}
         ]
-      ] }
+      ] },
+      { "geoLocationPolygon"=>
+        [
+          {"polygonPoint"=>{"pointLatitude"=>"80", "pointLongitude"=>"65"}},
+          {"polygonPoint"=>{"pointLatitude"=>"75", "pointLongitude"=>"55"}},
+          {"polygonPoint"=>{"pointLatitude"=>"73", "pointLongitude"=>"45"}},
+          {"polygonPoint"=>{"pointLatitude"=>"80", "pointLongitude"=>"65"}}
+        ]
+      }
       ]
     )
   end


### PR DESCRIPTION
This is to support backwards compatability where there is only one geoLocationPolygon per geoLocation.

## Purpose
This is to help fix this problem: https://github.com/datacite/bolognese/issues/110

In essence this is to support backwards compatabilty.

closes: #110

## Approach
Return array when multiple geoLocationPolygons per geoLocation and return singular object when only one per geoLocation.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
