### PR TITLE
Valid Funder DOIs are being rejected for not starting with a 5

### DIFF
--- a/lib/bolognese/doi_utils.rb
+++ b/lib/bolognese/doi_utils.rb
@@ -9,9 +9,8 @@ module Bolognese
     end
 
     def validate_funder_doi(doi)
-      regex = /\A(?:(http|https):\/(\/)?(dx\.)?(doi.org|handle.test.datacite.org)\/)?(doi:)?(10\.13039\/)?([1-9]\d+)\z/.match(doi)
-      # Compact to ensure nil is not returned for valid DOI's without a funder prefix, i.e 501100001711
-      doi = Array(regex).last
+      doi = Array(/\A(?:(http|https):\/(\/)?(dx\.)?(doi.org|handle.test.datacite.org)\/)?(doi:)?(10\.13039\/)?([1-9]\d+)\z/.match(doi)).last
+
       # remove non-printing whitespace and downcase
       if doi.present?
         doi.delete("\u200B").downcase

--- a/lib/bolognese/doi_utils.rb
+++ b/lib/bolognese/doi_utils.rb
@@ -9,10 +9,12 @@ module Bolognese
     end
 
     def validate_funder_doi(doi)
-      doi = Array(/\A(?:(http|https):\/(\/)?(dx\.)?(doi.org|handle.test.datacite.org)\/)?(doi:)?(10\.13039\/)?(5.+)\z/.match(doi)).last
+      regex = /\A(?:(http|https):\/(\/)?(dx\.)?(doi.org|handle.test.datacite.org)\/)?(doi:)?(10\.13039\/?(.+)|5[\d]{11})\z/.match(doi)
+      # Compact to ensure nil is not returned for valid DOI's without a funder prefix, i.e 501100001711
+      doi = Array(regex).compact.last
       # remove non-printing whitespace and downcase
       if doi.present?
-        doi.delete("\u200B").downcase 
+        doi.delete("\u200B").downcase
         "https://doi.org/10.13039/#{doi}"
       end
     end

--- a/lib/bolognese/doi_utils.rb
+++ b/lib/bolognese/doi_utils.rb
@@ -11,7 +11,7 @@ module Bolognese
     def validate_funder_doi(doi)
       regex = /\A(?:(http|https):\/(\/)?(dx\.)?(doi.org|handle.test.datacite.org)\/)?(doi:)?(10\.13039\/)?([1-9]\d+)\z/.match(doi)
       # Compact to ensure nil is not returned for valid DOI's without a funder prefix, i.e 501100001711
-      doi = Array(regex).compact.last
+      doi = Array(regex).last
       # remove non-printing whitespace and downcase
       if doi.present?
         doi.delete("\u200B").downcase

--- a/lib/bolognese/doi_utils.rb
+++ b/lib/bolognese/doi_utils.rb
@@ -9,7 +9,7 @@ module Bolognese
     end
 
     def validate_funder_doi(doi)
-      regex = /\A(?:(http|https):\/(\/)?(dx\.)?(doi.org|handle.test.datacite.org)\/)?(doi:)?(10\.13039\/?(.+)|5[\d]{11})\z/.match(doi)
+      regex = /\A(?:(http|https):\/(\/)?(dx\.)?(doi.org|handle.test.datacite.org)\/)?(doi:)?(10\.13039\/)?([1-9]\d+)\z/.match(doi)
       # Compact to ensure nil is not returned for valid DOI's without a funder prefix, i.e 501100001711
       doi = Array(regex).compact.last
       # remove non-printing whitespace and downcase

--- a/spec/doi_utils_spec.rb
+++ b/spec/doi_utils_spec.rb
@@ -273,19 +273,17 @@ describe Bolognese::Metadata, vcr: true do
       expect(response).to be_nil
     end
 
-    context "when the DOI does not start in 5" do
-      it "validates a DOI ID" do
-        doi = "10.13039/100000050"
-        response = subject.validate_funder_doi(doi)
-        expect(response).to eq("https://doi.org/10.13039/100000050")
-      end
-
-      it "validates a full DOI URI" do
-        doi = "https://doi.org/10.13039/100000050"
-        response = subject.validate_funder_doi(doi)
-        expect(response).to eq("https://doi.org/10.13039/100000050")
-      end
-    end
+    it { expect(subject.validate_funder_doi("10.13039/100000050")).to eq "https://doi.org/10.13039/100000050" }
+    it { expect(subject.validate_funder_doi("10.13039/100006492")).to eq "https://doi.org/10.13039/100006492" }
+    it { expect(subject.validate_funder_doi('http://handle.test.datacite.org/10.13039/100000080')).to eq "https://doi.org/10.13039/100000080" }
+    it { expect(subject.validate_funder_doi('https://doi.org/10.13039/100000001')).to eq "https://doi.org/10.13039/100000001" }
+    it { expect(subject.validate_funder_doi('http://doi.org/10.13039/501100001711')).to eq "https://doi.org/10.13039/501100001711" }
+    it { expect(subject.validate_funder_doi('https://dx.doi.org/10.13039/501100001711')).to eq "https://doi.org/10.13039/501100001711" }
+    it { expect(subject.validate_funder_doi('doi:10.13039/501100001711')).to eq "https://doi.org/10.13039/501100001711" }
+    it { expect(subject.validate_funder_doi('10.13039/501100001711')).to eq "https://doi.org/10.13039/501100001711" }
+    it { expect(subject.validate_funder_doi('501100001711')).to eq "https://doi.org/10.13039/501100001711" }
+    it { expect(subject.validate_funder_doi("https://doi.org/10.13039/5monkeymonkey")).to be_nil }
+    it { expect(subject.validate_funder_doi('10.13039/5monkeymonkey')).to be_nil }
   end
 
   context "validate prefix" do

--- a/spec/doi_utils_spec.rb
+++ b/spec/doi_utils_spec.rb
@@ -272,6 +272,20 @@ describe Bolognese::Metadata, vcr: true do
       response = subject.validate_funder_doi(doi)
       expect(response).to be_nil
     end
+
+    context "when the DOI does not start in 5" do
+      it "validates a DOI ID" do
+        doi = "10.13039/100000050"
+        response = subject.validate_funder_doi(doi)
+        expect(response).to eq("https://doi.org/10.13039/100000050")
+      end
+
+      it "validates a full DOI URI" do
+        doi = "https://doi.org/10.13039/100000050"
+        response = subject.validate_funder_doi(doi)
+        expect(response).to eq("https://doi.org/10.13039/100000050")
+      end
+    end
   end
 
   context "validate prefix" do


### PR DESCRIPTION
## Purpose

Resolve issue with valid funder DOIs being rejected because they do not start with a 5. 

For example, the following valid funder DOI:

https://doi.org/10.13039/100000050 

closes: https://github.com/datacite/bolognese/issues/108

## Approach

I have amended the regex that computes funder DOI validity inside of `Bolognese::DOIUtils.validate_funder_doi`. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
