### PR TITLE
Add support for book title and additional metadata when reading Crossref Book Chapter DOI

### DIFF
--- a/lib/bolognese/readers/crossref_reader.rb
+++ b/lib/bolognese/readers/crossref_reader.rb
@@ -50,26 +50,21 @@ module Bolognese
           book_set_metadata = meta.dig("crossref", "book", "book_set_metadata")
           bibliographic_metadata = meta.dig("crossref", "book", "content_item") || book_metadata || book_series_metadata || book_set_metadata
           resource_type = bibliographic_metadata.fetch("component_type", nil) ? "book-" + bibliographic_metadata.fetch("component_type") : "book"
-          # publisher = if book_metadata.present?
-          #               book_metadata.dig("publisher", "publisher_name")
-          #             elsif book_series_metadata.present?
-          #               book_series_metadata.dig("publisher", "publisher_name")
-          #             end
         when "conference"
-          event_metadata = meta.dig("crossref", "conference", "event_metadata") || {}
+          event_metadata = meta.dig("crossref", "conference", "event_metadata") || {}
           bibliographic_metadata = meta.dig("crossref", "conference", "conference_paper").to_h
         when "journal"
-          journal_metadata = meta.dig("crossref", "journal", "journal_metadata") || {}
+          journal_metadata = meta.dig("crossref", "journal", "journal_metadata") || {}
           journal_issue = meta.dig("crossref", "journal", "journal_issue") || {}
           journal_article = meta.dig("crossref", "journal", "journal_article") || {}
           bibliographic_metadata = journal_article.presence || journal_issue.presence || journal_metadata
           program_metadata = bibliographic_metadata.dig("crossmark", "custom_metadata", "program") || bibliographic_metadata.dig("program")
           resource_type = if journal_article.present?
-                              "journal_article"
-                            elsif journal_issue.present?
-                              "journal_issue"
-                            else
-                              "journal"
+                            "journal_article"
+                          elsif journal_issue.present?
+                            "journal_issue"
+                          else
+                            "journal"
                             end
         when "posted_content"
           bibliographic_metadata = meta.dig("crossref", "posted_content").to_h
@@ -140,7 +135,8 @@ module Bolognese
         state = meta.present? || read_options.present? ? "findable" : "not_found"
 
         related_identifiers = Array.wrap(crossref_is_part_of(journal_metadata)) + Array.wrap(crossref_references(bibliographic_metadata))
-        container = if journal_metadata.present? || book_metadata.present?
+
+        container = if journal_metadata.present?
                       issn = normalize_issn(journal_metadata.to_h.fetch("issn", nil))
 
                       { "type" => "Journal",
@@ -151,6 +147,19 @@ module Bolognese
                         "issue" => parse_attributes(journal_issue.dig("issue")),
                         "firstPage" => bibliographic_metadata.dig("pages", "first_page") || parse_attributes(journal_article.to_h.dig("publisher_item", "item_number"), first: true),
                         "lastPage" => bibliographic_metadata.dig("pages", "last_page") }.compact
+
+                    # By using book_metadata, we can account for where resource_type is `BookChapter` and not assume its a whole book
+                    elsif book_metadata.present?
+                      identifiers = crossref_alternate_identifiers(book_metadata)
+
+                      {
+                        "type" => "Book",
+                        "title" => book_metadata.dig("titles", "title"),
+                        "firstPage" => bibliographic_metadata.dig("pages", "first_page"),
+                        "lastPage" => bibliographic_metadata.dig("pages", "last_page"),
+                        "identifiers" => identifiers,
+                      }.compact
+
                     elsif book_series_metadata.to_h.fetch("series_metadata", nil).present?
                       issn = normalize_issn(book_series_metadata.dig("series_metadata", "issn"))
 
@@ -162,7 +171,10 @@ module Bolognese
                     end
 
         id = normalize_doi(options[:doi] || options[:id] || bibliographic_metadata.dig("doi_data", "doi"))
-        identifiers = crossref_alternate_identifiers(bibliographic_metadata)
+
+        # Let sections override this in case of alternative metadata structures, such as book chapters, which
+        # have their meta inside `content_item`, but the main book indentifers inside of `book_metadata`
+        identifiers ||= crossref_alternate_identifiers(bibliographic_metadata)
 
         { "id" => id,
           "types" => types,
@@ -187,8 +199,7 @@ module Bolognese
           "sizes" => nil,
           "schema_version" => nil,
           "state" => state,
-          "date_registered" => date_registered
-        }.merge(read_options)
+          "date_registered" => date_registered }.merge(read_options)
       end
 
       def crossref_alternate_identifiers(bibliographic_metadata)

--- a/lib/bolognese/readers/crossref_reader.rb
+++ b/lib/bolognese/readers/crossref_reader.rb
@@ -50,6 +50,11 @@ module Bolognese
           book_set_metadata = meta.dig("crossref", "book", "book_set_metadata")
           bibliographic_metadata = meta.dig("crossref", "book", "content_item") || book_metadata || book_series_metadata || book_set_metadata
           resource_type = bibliographic_metadata.fetch("component_type", nil) ? "book-" + bibliographic_metadata.fetch("component_type") : "book"
+          # publisher = if book_metadata.present?
+          #               book_metadata.dig("publisher", "publisher_name")
+          #             elsif book_series_metadata.present?
+          #               book_series_metadata.dig("publisher", "publisher_name")
+          #             end
         when "conference"
           event_metadata = meta.dig("crossref", "conference", "event_metadata") || {}
           bibliographic_metadata = meta.dig("crossref", "conference", "conference_paper").to_h

--- a/lib/bolognese/readers/crossref_reader.rb
+++ b/lib/bolognese/readers/crossref_reader.rb
@@ -65,11 +65,11 @@ module Bolognese
           bibliographic_metadata = journal_article.presence || journal_issue.presence || journal_metadata
           program_metadata = bibliographic_metadata.dig("crossmark", "custom_metadata", "program") || bibliographic_metadata.dig("program")
           resource_type = if journal_article.present?
-                            "journal_article"
-                          elsif journal_issue.present?
-                            "journal_issue"
-                          else
-                            "journal"
+                              "journal_article"
+                            elsif journal_issue.present?
+                              "journal_issue"
+                            else
+                              "journal"
                             end
         when "posted_content"
           bibliographic_metadata = meta.dig("crossref", "posted_content").to_h

--- a/lib/bolognese/readers/crossref_reader.rb
+++ b/lib/bolognese/readers/crossref_reader.rb
@@ -204,7 +204,8 @@ module Bolognese
           "sizes" => nil,
           "schema_version" => nil,
           "state" => state,
-          "date_registered" => date_registered }.merge(read_options)
+          "date_registered" => date_registered
+        }.merge(read_options)
       end
 
       def crossref_alternate_identifiers(bibliographic_metadata)

--- a/lib/bolognese/writers/jats_writer.rb
+++ b/lib/bolognese/writers/jats_writer.rb
@@ -76,7 +76,9 @@ module Bolognese
       end
 
       def insert_source(xml)
-        if is_article? || is_data? || is_chapter?
+        if is_chapter?
+          xml.source(publisher)
+        elsif is_article? || is_data?
           xml.source(container && container["title"] || publisher)
         else
           xml.source(parse_attributes(titles, content: "title", first: true))

--- a/spec/readers/crossref_reader_spec.rb
+++ b/spec/readers/crossref_reader_spec.rb
@@ -372,6 +372,11 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.publication_year).to eq("2015")
       expect(subject.publisher).to eq("Springer Science and Business Media LLC")
       expect(subject.agency).to eq("crossref")
+      expect(subject.container["type"]).to eq("Book")
+      expect(subject.container["title"]).to eq("Shoulder Stiffness")
+      expect(subject.container["firstPage"]).to eq("155")
+      expect(subject.container["lastPage"]).to eq("158")
+      expect(subject.container["identifiers"]).to eq([{"identifier"=>"978-3-662-46369-7", "identifierType"=>"ISBN"}])
     end
 
     it "another book chapter" do
@@ -387,6 +392,10 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.publication_year).to eq("2018")
       expect(subject.publisher).to eq("Springer Science and Business Media LLC")
       expect(subject.agency).to eq("crossref")
+      expect(subject.container["type"]).to eq("Book Series")
+      expect(subject.container["title"]).to eq("SpringerBriefs in Medical Earth Sciences")
+      expect(subject.container["identifier"]).to eq("2523-3629")
+      expect(subject.container["identifierType"]).to eq("ISSN")
     end
 
     it "yet another book chapter" do
@@ -402,6 +411,11 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.publication_year).to eq("2012")
       expect(subject.publisher).to eq("IGI Global")
       expect(subject.agency).to eq("crossref")
+      expect(subject.container["type"]).to eq("Book")
+      expect(subject.container["title"]).to eq("Graph-Based Methods in Computer Vision")
+      expect(subject.container["firstPage"]).to eq("72")
+      expect(subject.container["lastPage"]).to eq("94")
+      expect(subject.container["identifiers"]).to eq([{"identifier"=>"9781466618916", "identifierType"=>"ISBN"}])
     end
 
     it "missing creator" do


### PR DESCRIPTION
## Purpose
Book chapters do not refer to their parent book titles in the returned metadata. 

There seems to be a small side effect in the way the container is assigned for book chapters (https://github.com/datacite/bolognese/blob/master/lib/bolognese/readers/crossref_reader.rb#L143), `journal_metadata.present? || book_metadata.present?` are both checked, but `book_metadata` is never used - this limits the book related data that is added to the `container`. 

## Approach
A small adjustment to the way the `crossref_reader` method checks for the type of work it is currently parsing. 

`journal_metadata` is checked if available and if not, `book_metadata` is checked for presence and assigns missing metadata such as book title to `container["title"]`. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
