### PR TITLE
Fix missing affiliation identifier

### DIFF
--- a/lib/bolognese/author_utils.rb
+++ b/lib/bolognese/author_utils.rb
@@ -138,14 +138,16 @@ module Bolognese
 
     def get_affiliations(affiliations)
       Array.wrap(affiliations).map do |a|
+        affiliation_identifier = nil
         if a.is_a?(String)
           name = a.squish
-          affiliation_identifier = nil
           affiliation_identifier_scheme = nil
           scheme_uri = nil
         else
-          affiliation_identifier = a["affiliationIdentifier"]
-          affiliation_identifier = !affiliation_identifier.to_s.start_with?("https://") && a["schemeURI"].present? ? normalize_id(a["schemeURI"] + affiliation_identifier) : normalize_id(affiliation_identifier)
+          if a["affiliationIdentifier"].present?
+            affiliation_identifier = a["affiliationIdentifier"]
+            affiliation_identifier = !affiliation_identifier.to_s.start_with?("https://") && a["schemeURI"].present? ? normalize_id(a["schemeURI"] + affiliation_identifier) : normalize_id(affiliation_identifier)
+          end
           name = a["__content__"].to_s.squish.presence
           affiliation_identifier_scheme = a["affiliationIdentifierScheme"]
           scheme_uri = a["SchemeURI"]

--- a/lib/bolognese/author_utils.rb
+++ b/lib/bolognese/author_utils.rb
@@ -146,7 +146,10 @@ module Bolognese
         else
           if a["affiliationIdentifier"].present?
             affiliation_identifier = a["affiliationIdentifier"]
-            affiliation_identifier = !affiliation_identifier.to_s.start_with?("https://") && a["schemeURI"].present? ? normalize_id(a["schemeURI"] + affiliation_identifier) : normalize_id(affiliation_identifier)
+            if a["schemeURI"].present?
+              schemeURI = a["schemeURI"].end_with?("/") ? a["schemeURI"] : a["schemeURI"] + "/"
+            end
+            affiliation_identifier = !affiliation_identifier.to_s.start_with?("https://") && schemeURI.present? ? normalize_id(schemeURI + affiliation_identifier) : normalize_id(affiliation_identifier)
           end
           name = a["__content__"].to_s.squish.presence
           affiliation_identifier_scheme = a["affiliationIdentifierScheme"]


### PR DESCRIPTION
## Purpose
This fixes https://github.com/datacite/bolognese/issues/116

In addition I noticed that if appending a schemeURI without trailing slash you'd end up with identifiers like:
https://ror.org04wxnsj81

So I added additional fix for that.

closes: #116

## Approach
Fairly straightforward present check and ends_with

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
