### PR TITLE
Allow Orcid URLs to have been issued from the sandbox

### DIFF
--- a/lib/bolognese/utils.rb
+++ b/lib/bolognese/utils.rb
@@ -574,7 +574,7 @@ module Bolognese
     end
 
     def validate_orcid(orcid)
-      orcid = Array(/\A(?:(http|https):\/\/(www\.)?orcid\.org\/)?(\d{4}[[:space:]-]\d{4}[[:space:]-]\d{4}[[:space:]-]\d{3}[0-9X]+)\z/.match(orcid)).last
+      orcid = Array(/\A(?:(?:http|https):\/\/(?:(?:www|sandbox)?\.)?orcid\.org\/)?(\d{4}[[:space:]-]\d{4}[[:space:]-]\d{4}[[:space:]-]\d{3}[0-9X]+)\z/.match(orcid)).last
       orcid.gsub(/[[:space:]]/, "-") if orcid.present?
     end
 

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -64,6 +64,18 @@ describe Bolognese::Metadata, vcr: true do
       expect(response).to eq("0000-0002-1394-3097")
     end
 
+    it "validate_orcid sandbox" do
+      orcid = "http://sandbox.orcid.org/0000-0002-2590-225X"
+      response = subject.validate_orcid(orcid)
+      expect(response).to eq("0000-0002-2590-225X")
+    end
+
+    it "validate_orcid sandbox https" do
+      orcid = "https://sandbox.orcid.org/0000-0002-2590-225X"
+      response = subject.validate_orcid(orcid)
+      expect(response).to eq("0000-0002-2590-225X")
+    end
+
     it "validate_orcid wrong id" do
       orcid = "0000-0002-1394-309"
       response = subject.validate_orcid(orcid)


### PR DESCRIPTION
## Purpose

Orcid URLs created within the Sandbox environment are not currently allowed. 

closes: https://github.com/datacite/bolognese/issues/120

## Approach

I have amended the Orcid Regex slightly to allow the "sandbox" subdomain. 


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
