### PR TITLE
Including a schemeURI with a nameIdentifier that is a URL will concat…

### DIFF
--- a/lib/bolognese/author_utils.rb
+++ b/lib/bolognese/author_utils.rb
@@ -35,21 +35,15 @@ module Bolognese
             "nameIdentifier" => normalize_orcid(ni["__content__"]),
             "schemeUri" => "https://orcid.org",
             "nameIdentifierScheme" => "ORCID" }.compact
-        elsif ni["schemeURI"].present?
-          name_identifier = nil
-          if ni["__content__"].present?
-            name_identifier = ni["__content__"].to_s.strip
-            schemeURI = ni["schemeURI"].end_with?("/") ? ni["schemeURI"] : ni["schemeURI"] + "/"
-            name_identifier = !name_identifier.start_with?("https://") && schemeURI.present? ? normalize_id(schemeURI +  name_identifier) : normalize_id(name_identifier)
-          end 
+        elsif ni["nameIdentifierScheme"] == "ROR"
           {
-            "nameIdentifier" => name_identifier,
-            "schemeUri" => ni["schemeURI"],
-            "nameIdentifierScheme" => ni["nameIdentifierScheme"] }.compact
+            "nameIdentifier" => normalize_ror(ni["__content__"]),
+            "schemeUri" => "https://ror.org",
+            "nameIdentifierScheme" => "ROR" }.compact
         else
           {
             "nameIdentifier" => ni["__content__"],
-            "schemeUri" => nil,
+            "schemeUri" => ni.fetch("schemeURI", nil),
             "nameIdentifierScheme" => ni["nameIdentifierScheme"] }.compact
         end
       end.presence

--- a/lib/bolognese/author_utils.rb
+++ b/lib/bolognese/author_utils.rb
@@ -36,9 +36,15 @@ module Bolognese
             "schemeUri" => "https://orcid.org",
             "nameIdentifierScheme" => "ORCID" }.compact
         elsif ni["schemeURI"].present?
+          name_identifier = nil
+          if ni["__content__"].present?
+            name_identifier = ni["__content__"].to_s.strip
+            schemeURI = ni["schemeURI"].end_with?("/") ? ni["schemeURI"] : ni["schemeURI"] + "/"
+            name_identifier = !name_identifier.start_with?("https://") && schemeURI.present? ? normalize_id(schemeURI +  name_identifier) : normalize_id(name_identifier)
+          end 
           {
-            "nameIdentifier" => ni["schemeURI"].to_s + ni["__content__"].to_s,
-            "schemeUri" => ni["schemeURI"].to_s,
+            "nameIdentifier" => name_identifier,
+            "schemeUri" => ni["schemeURI"],
             "nameIdentifierScheme" => ni["nameIdentifierScheme"] }.compact
         else
           {

--- a/lib/bolognese/utils.rb
+++ b/lib/bolognese/utils.rb
@@ -578,6 +578,10 @@ module Bolognese
       orcid.gsub(/[[:space:]]/, "-") if orcid.present?
     end
 
+    def validate_ror(ror)
+      Array(/^(?:(?:(?:http|https):\/\/)?ror\.org\/)?(0\w{6}\d{2})$/.match(ror)).last
+    end
+
     def validate_orcid_scheme(orcid_scheme)
       Array(/\A(http|https):\/\/(www\.)?(orcid\.org)/.match(orcid_scheme)).last
     end
@@ -657,6 +661,14 @@ module Bolognese
 
       # turn ORCID ID into URL
       "https://orcid.org/" + Addressable::URI.encode(orcid)
+    end
+
+    def normalize_ror(ror)
+      ror = validate_ror(ror)
+      return nil unless ror.present?
+
+      # turn ROR into URL
+      "https://ror.org/" + Addressable::URI.encode(ror)
     end
 
     def normalize_ids(ids: nil, relation_type: nil)

--- a/spec/author_utils_spec.rb
+++ b/spec/author_utils_spec.rb
@@ -160,6 +160,16 @@ describe Bolognese::Metadata, vcr: true do
     end
   end
 
+  it "URL nameIdentifier with schemeURI" do
+    input = fixture_path + 'datacite-example-nameIdentifier-with-schemeURI.xml'
+    subject = Bolognese::Metadata.new(input: input, from: "datacite")
+    expect(subject.creators[1]).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52", "schemeUri"=>"https://ror.org/", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
+    expect(subject.creators[2]).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
+    expect(subject.creators[3]).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station", "nameIdentifiers"=> [{"nameIdentifier"=>"04sk0et52", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
+    expect(subject.contributors.first).to eq("nameType"=>"Organizational", "name"=>" Gump South Pacific Research Station ", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52",   "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[], "contributorType"=>"Producer")
+    expect(subject.contributors.last).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station (Moorea.Berkeley.Edu)", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52", "schemeUri"=>"https://ror.org/", "nameIdentifierScheme"=>"ROR"}],"affiliation"=>[], "contributorType"=>"Sponsor")
+  end
+
   context "authors_as_string" do
     let(:author_with_organization) { [{"type"=>"Person",
                                        "id"=>"http://orcid.org/0000-0003-0077-4738",

--- a/spec/author_utils_spec.rb
+++ b/spec/author_utils_spec.rb
@@ -133,7 +133,7 @@ describe Bolognese::Metadata, vcr: true do
         "familyName" => "Schumacher",
         "givenName" => "Heinrich Christian",
         "name" => "Schumacher, Heinrich Christian",
-        "nameIdentifiers" => [{"nameIdentifier"=>"http://d-nb.info/gnd/118611593", "nameIdentifierScheme"=>"GND", "schemeUri"=>"http://d-nb.info/gnd/"}],
+        "nameIdentifiers" => [{"nameIdentifier"=>"118611593", "nameIdentifierScheme"=>"GND", "schemeUri"=>"http://d-nb.info/gnd/"}],
         "nameType" => "Personal")
     end
 
@@ -142,7 +142,7 @@ describe Bolognese::Metadata, vcr: true do
       subject = Bolognese::Metadata.new(input: input, from: "datacite")
       meta = Maremma.from_xml(subject.raw).fetch("resource", {})
       response = subject.get_one_author(meta.dig("creators", "creator"))
-      expect(response).to eq("nameType"=>"Personal", "name"=>"Dubos, Thomas", "givenName"=>"Thomas", "familyName"=>"Dubos", "affiliation" => [{"name"=>"&#201;cole Polytechnique Laboratoire de M&#233;t&#233;orologie Dynamique"}], "nameIdentifiers" => [{"nameIdentifier"=>"http://isni.org/isni/0000 0003 5752 6882", "nameIdentifierScheme"=>"ISNI", "schemeUri"=>"http://isni.org/isni/"}, {"nameIdentifier"=>"https://orcid.org/0000-0003-4514-4211", "nameIdentifierScheme"=>"ORCID", "schemeUri"=>"https://orcid.org"}])
+      expect(response).to eq("nameType"=>"Personal", "name"=>"Dubos, Thomas", "givenName"=>"Thomas", "familyName"=>"Dubos", "affiliation" => [{"name"=>"&#201;cole Polytechnique Laboratoire de M&#233;t&#233;orologie Dynamique"}], "nameIdentifiers" => [{"nameIdentifier"=>"0000 0003 5752 6882", "nameIdentifierScheme"=>"ISNI", "schemeUri"=>"http://isni.org/isni/"}, {"nameIdentifier"=>"https://orcid.org/0000-0003-4514-4211", "nameIdentifierScheme"=>"ORCID", "schemeUri"=>"https://orcid.org"}])
     end
 
     it "nameType organizational" do
@@ -160,14 +160,16 @@ describe Bolognese::Metadata, vcr: true do
     end
   end
 
-  it "URL nameIdentifier with schemeURI" do
-    input = fixture_path + 'datacite-example-nameIdentifier-with-schemeURI.xml'
+  it "has ROR nameIdentifiers" do
+    input = fixture_path + 'datacite-example-ROR-nameIdentifiers.xml'
     subject = Bolognese::Metadata.new(input: input, from: "datacite")
-    expect(subject.creators[1]).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52", "schemeUri"=>"https://ror.org/", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
-    expect(subject.creators[2]).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
-    expect(subject.creators[3]).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station", "nameIdentifiers"=> [{"nameIdentifier"=>"04sk0et52", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
-    expect(subject.contributors.first).to eq("nameType"=>"Organizational", "name"=>" Gump South Pacific Research Station ", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52",   "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[], "contributorType"=>"Producer")
-    expect(subject.contributors.last).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station (Moorea.Berkeley.Edu)", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52", "schemeUri"=>"https://ror.org/", "nameIdentifierScheme"=>"ROR"}],"affiliation"=>[], "contributorType"=>"Sponsor")
+    expect(subject.creators[1]).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
+    expect(subject.creators[2]).to eq("nameType"=>"Organizational", "name"=>"University Of Vic", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/006zjws59", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
+    expect(subject.creators[3]).to eq("nameType"=>"Organizational", "name"=>"University Of Kivu", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/01qfhxr31", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
+    expect(subject.creators[4]).to eq("nameType"=>"Organizational", "name"=>"សាកលវិទ្យាល័យកម្ពុជា", "nameIdentifiers"=> [{"nameIdentifier"=>"http://ror.org/025e3rc84", "nameIdentifierScheme"=>"RORS"}], "affiliation"=>[])
+    expect(subject.creators[5]).to eq("nameType"=>"Organizational", "name"=>"جامعة زاخۆ", "nameIdentifiers"=> [{"nameIdentifier"=>"05sd1pz50", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"RORS"}], "affiliation"=>[])
+    expect(subject.contributors.first).to eq("nameType"=>"Organizational", "name"=>" Nawroz University ", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04gp75d48", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[], "contributorType"=>"Producer")
+    expect(subject.contributors.last).to eq("nameType"=>"Organizational", "name"=>"University Of Greenland (Https://Www.Uni.Gl/)", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/00t5j6b61", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}],"affiliation"=>[], "contributorType"=>"Sponsor")
   end
 
   context "authors_as_string" do

--- a/spec/fixtures/datacite-example-ROR-nameIdentifiers.xml
+++ b/spec/fixtures/datacite-example-ROR-nameIdentifiers.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-%s http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+    <identifier identifierType="DOI">10.48321/D1Z60Q</identifier>
+    <creators>
+        <creator>
+            <creatorName nameType="Personal">Erin Robinson</creatorName>
+            <nameIdentifier schemeURI="https://orcid.org/" nameIdentifierScheme="ORCID"> https://orcid.org/0000-0001-9998-0114 </nameIdentifier>
+            <affiliation schemeURI="https://ror.org" affiliationIdentifier="https://ror.org/05bp8ka05" affiliationIdentifierScheme="ROR"> Metadata Game Changers </affiliation>
+        </creator>
+        <creator>
+            <creatorName nameType="Organizational">Gump South Pacific Research Station</creatorName>
+            <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org/">https://ror.org/04sk0et52</nameIdentifier>
+        </creator>
+        <creator>
+            <creatorName nameType="Organizational">University of Vic</creatorName>
+            <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org">006zjws59</nameIdentifier>
+        </creator>
+        <creator>
+            <creatorName nameType="Organizational">University of Kivu</creatorName>
+            <nameIdentifier nameIdentifierScheme="ROR">http://ror.org/01qfhxr31</nameIdentifier>
+        </creator>
+        <creator>
+            <creatorName nameType="Organizational">សាកលវិទ្យាល័យកម្ពុជា</creatorName>
+            <nameIdentifier nameIdentifierScheme="RORS">http://ror.org/025e3rc84</nameIdentifier>
+        </creator>
+        <creator>
+            <creatorName nameType="Organizational">جامعة زاخۆ</creatorName>
+            <nameIdentifier nameIdentifierScheme="RORS" schemeURI="https://ror.org">05sd1pz50</nameIdentifier>
+        </creator>
+    </creators>
+    <titles>
+        <title xml:lang="en-US">Genomic Standards Consortium (GSC) Island Sampling Day: Moorea Reef to Ridges Genomic Transect</title>
+    </titles>
+    <publisher xml:lang="en-US">DMPHub</publisher>
+    <publicationYear>2022</publicationYear>
+    <contributors>
+        <contributor contributorType="Producer">
+            <contributorName nameType="Organizational"> Nawroz University </contributorName>
+            <nameIdentifier nameIdentifierScheme="ROR">04gp75d48</nameIdentifier>
+        </contributor>
+        <contributor contributorType="ProjectLeader">
+            <contributorName nameType="Personal">Neil Davies</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0001-8085-5014</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/01an7q238" affiliationIdentifierScheme="ROR"> University of California, Berkeley </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectLeader">
+            <contributorName nameType="Personal">Ramona Walls</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0001-8815-0078</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/03m2x1q45" affiliationIdentifierScheme="ROR"> University of Arizona </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectLeader">
+            <contributorName nameType="Personal">Serge Planes</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0002-5689-5371</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/02feahw73" affiliationIdentifierScheme="ROR"> French National Centre for Scientific Research </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectLeader">
+            <contributorName nameType="Personal">Chris Meyer</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0003-2501-7952</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/01pp8nd67" affiliationIdentifierScheme="ROR"> Smithsonian Institution </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectLeader">
+            <contributorName nameType="Personal">Lynn Schriml</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0001-8910-9851</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/04rq5mt64" affiliationIdentifierScheme="ROR"> University of Maryland, Baltimore </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectMember">
+            <contributorName nameType="Personal">Scott Tighe</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0002-3988-0741</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/0155zta11" affiliationIdentifierScheme="ROR"> University of Vermont </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectMember">
+            <contributorName nameType="Personal">Pier Luigi Buttigieg</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0002-4366-3088</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/02h2x0161" affiliationIdentifierScheme="ROR"> GEOMAR Helmholtz Centre for Ocean Research Kiel </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectMember">
+            <contributorName nameType="Personal">Raïssa Meyer</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0002-2996-719X</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/032e6b942" affiliationIdentifierScheme="ROR"> Alfred Wegener Institute for Polar and Marine Research </affiliation>
+        </contributor>
+        <contributor contributorType="Sponsor">
+            <contributorName nameType="Organizational">University of Greenland (https://www.uni.gl/)</contributorName>
+            <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org/">https://ror.org/00t5j6b61</nameIdentifier>
+        </contributor>
+    </contributors>
+    <language>en-US</language>
+    <resourceType resourceTypeGeneral="OutputManagementPlan">Data Management Plan</resourceType>
+    <descriptions>
+        <description xml:lang="en-US" descriptionType="Abstract"> &lt;p&gt;Here we describe a project that supports the mission of the Genomic Standards Consortium (GSC) and contributes to the “Ocean Biomolecular Observations Network” (OBON) and the “Ocean Best Practice System” (OBPS - Omics Task Team), flagship programs of the UN Ocean Decade of Ocean Science for Sustainable Development. The project serves as a test case for two related infrastructure projects that aim to improve standards, policies, and best practices in sample collection: Sampling Nature (SN) Research Coordination Network and the Internet of Samples (iSamples).&lt;/p&gt;  &lt;p&gt;&lt;strong&gt;The project’s primary goal (first paper) is methodologica&lt;/strong&gt;l: (i) to demonstrate the value of genomic standards for both genomic research and secondary interdisciplinary research, (ii) to highlight the importance of data curation workflows that follow FAIR+CARE principles maximizing the potential for appropriate reuse of data and material samples, (iii) to illustrate the challenges that remain in implementing those standards - including ethical, legal, and social aspects, and (iv) to demonstrate some of the tools, infrastructures, and best-practices available for overcoming these challenges. This paper will include all the elements of a data paper (primary publication of the initial data collected), but with broader discussion around it as a use case for metadata standards and best practices in multi-omic sampling.&lt;/p&gt;  &lt;p&gt;&lt;strong&gt;The project’s secondary goal (second paper) is to address research questions including&lt;/strong&gt;: (1) To what extent can one day of environmental sampling, and subsequent multi-omic analyses, characterize the ecological state of an island (coupled marine-terrestrial ecosystem)? (2) To what extent might such surveys serve as baselines for futuromic study (future analysis of biomolecules from the material samples archived), and (3) if repeated, could these surveys help address long-term changes in genomic biodiversity? (4) How does marine and terrestrial eDNA change across a transect? Moorea is one of the most well-described biotas in the world and has one of the longest and most intensive time-series of ecological data, particularly for coral reef ecosystems. It thus serves as a powerful calibration site for such a study.&lt;/p&gt;  &lt;p&gt;&lt;br&gt;&lt;strong&gt;The project’s broader impact goal is public outreach &lt;/strong&gt;– if possible engage local citizen scientists/schools, ideally through Fare Natura (ecomuseum at entrance to the Opunohu Valley. (Also perhaps local Associations that might be interested, e.g., Te Pu Atitia). Sampling Nature will produce an outreach videos based on this Island Sampling Day.&lt;/p&gt; </description>
+    </descriptions>
+    <fundingReferences>
+        <fundingReference>
+            <funderName>Genomic Standards Consortium</funderName>
+        </fundingReference>
+    </fundingReferences>
+    <relatedIdentifiers>
+        <relatedIdentifier relationType="IsMetadataFor" relatedIdentifierType="URL"> https://dmptool.org/api/v2/plans/74309.pdf </relatedIdentifier>
+        <relatedIdentifier relationType="Cites" relatedIdentifierType="URL"> https://n2t.net/ark:/21547/EBW2 </relatedIdentifier>
+        <relatedIdentifier relationType="Cites" relatedIdentifierType="URL"> https://docs.google.com/document/d/1EYgEEUroMBiTNc5Px11_44G-B17JtTgyssyNkK3hV_U/edit#heading=h.ckwz8v2yry1q </relatedIdentifier>
+    </relatedIdentifiers>
+</resource>

--- a/spec/fixtures/datacite-example-nameIdentifier-with-schemeURI.xml
+++ b/spec/fixtures/datacite-example-nameIdentifier-with-schemeURI.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-%s http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+    <identifier identifierType="DOI">10.48321/D1Z60Q</identifier>
+    <creators>
+        <creator>
+            <creatorName nameType="Personal">Erin Robinson</creatorName>
+            <nameIdentifier schemeURI="https://orcid.org/" nameIdentifierScheme="ORCID"> https://orcid.org/0000-0001-9998-0114 </nameIdentifier>
+            <affiliation schemeURI="https://ror.org" affiliationIdentifier="https://ror.org/05bp8ka05" affiliationIdentifierScheme="ROR"> Metadata Game Changers </affiliation>
+        </creator>
+        <creator>
+            <creatorName nameType="Organizational">Gump South Pacific Research Station</creatorName>
+            <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org/">https://ror.org/04sk0et52</nameIdentifier>
+        </creator>
+        <creator>
+            <creatorName nameType="Organizational">Gump South Pacific Research Station</creatorName>
+            <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org">04sk0et52</nameIdentifier>
+        </creator>
+        <creator>
+            <creatorName nameType="Organizational">Gump South Pacific Research Station</creatorName>
+            <nameIdentifier nameIdentifierScheme="ROR">04sk0et52</nameIdentifier>
+        </creator>
+    </creators>
+    <titles>
+        <title xml:lang="en-US">Genomic Standards Consortium (GSC) Island Sampling Day: Moorea Reef to Ridges Genomic Transect</title>
+    </titles>
+    <publisher xml:lang="en-US">DMPHub</publisher>
+    <publicationYear>2022</publicationYear>
+    <contributors>
+        <contributor contributorType="Producer">
+            <contributorName nameType="Organizational"> Gump South Pacific Research Station </contributorName>
+            <nameIdentifier nameIdentifierScheme="ROR">https://ror.org/04sk0et52</nameIdentifier>
+        </contributor>
+        <contributor contributorType="ProjectLeader">
+            <contributorName nameType="Personal">Neil Davies</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0001-8085-5014</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/01an7q238" affiliationIdentifierScheme="ROR"> University of California, Berkeley </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectLeader">
+            <contributorName nameType="Personal">Ramona Walls</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0001-8815-0078</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/03m2x1q45" affiliationIdentifierScheme="ROR"> University of Arizona </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectLeader">
+            <contributorName nameType="Personal">Serge Planes</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0002-5689-5371</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/02feahw73" affiliationIdentifierScheme="ROR"> French National Centre for Scientific Research </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectLeader">
+            <contributorName nameType="Personal">Chris Meyer</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0003-2501-7952</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/01pp8nd67" affiliationIdentifierScheme="ROR"> Smithsonian Institution </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectLeader">
+            <contributorName nameType="Personal">Lynn Schriml</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0001-8910-9851</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/04rq5mt64" affiliationIdentifierScheme="ROR"> University of Maryland, Baltimore </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectMember">
+            <contributorName nameType="Personal">Scott Tighe</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0002-3988-0741</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/0155zta11" affiliationIdentifierScheme="ROR"> University of Vermont </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectMember">
+            <contributorName nameType="Personal">Pier Luigi Buttigieg</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0002-4366-3088</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/02h2x0161" affiliationIdentifierScheme="ROR"> GEOMAR Helmholtz Centre for Ocean Research Kiel </affiliation>
+        </contributor>
+        <contributor contributorType="ProjectMember">
+            <contributorName nameType="Personal">Raïssa Meyer</contributorName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">https://orcid.org/0000-0002-2996-719X</nameIdentifier>
+            <affiliation affiliationIdentifier="https://ror.org/032e6b942" affiliationIdentifierScheme="ROR"> Alfred Wegener Institute for Polar and Marine Research </affiliation>
+        </contributor>
+        <contributor contributorType="Sponsor">
+            <contributorName nameType="Organizational">Gump South Pacific Research Station (moorea.berkeley.edu)</contributorName>
+            <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org/">https://ror.org/04sk0et52</nameIdentifier>
+        </contributor>
+    </contributors>
+    <language>en-US</language>
+    <resourceType resourceTypeGeneral="OutputManagementPlan">Data Management Plan</resourceType>
+    <descriptions>
+        <description xml:lang="en-US" descriptionType="Abstract"> &lt;p&gt;Here we describe a project that supports the mission of the Genomic Standards Consortium (GSC) and contributes to the “Ocean Biomolecular Observations Network” (OBON) and the “Ocean Best Practice System” (OBPS - Omics Task Team), flagship programs of the UN Ocean Decade of Ocean Science for Sustainable Development. The project serves as a test case for two related infrastructure projects that aim to improve standards, policies, and best practices in sample collection: Sampling Nature (SN) Research Coordination Network and the Internet of Samples (iSamples).&lt;/p&gt;  &lt;p&gt;&lt;strong&gt;The project’s primary goal (first paper) is methodologica&lt;/strong&gt;l: (i) to demonstrate the value of genomic standards for both genomic research and secondary interdisciplinary research, (ii) to highlight the importance of data curation workflows that follow FAIR+CARE principles maximizing the potential for appropriate reuse of data and material samples, (iii) to illustrate the challenges that remain in implementing those standards - including ethical, legal, and social aspects, and (iv) to demonstrate some of the tools, infrastructures, and best-practices available for overcoming these challenges. This paper will include all the elements of a data paper (primary publication of the initial data collected), but with broader discussion around it as a use case for metadata standards and best practices in multi-omic sampling.&lt;/p&gt;  &lt;p&gt;&lt;strong&gt;The project’s secondary goal (second paper) is to address research questions including&lt;/strong&gt;: (1) To what extent can one day of environmental sampling, and subsequent multi-omic analyses, characterize the ecological state of an island (coupled marine-terrestrial ecosystem)? (2) To what extent might such surveys serve as baselines for futuromic study (future analysis of biomolecules from the material samples archived), and (3) if repeated, could these surveys help address long-term changes in genomic biodiversity? (4) How does marine and terrestrial eDNA change across a transect? Moorea is one of the most well-described biotas in the world and has one of the longest and most intensive time-series of ecological data, particularly for coral reef ecosystems. It thus serves as a powerful calibration site for such a study.&lt;/p&gt;  &lt;p&gt;&lt;br&gt;&lt;strong&gt;The project’s broader impact goal is public outreach &lt;/strong&gt;– if possible engage local citizen scientists/schools, ideally through Fare Natura (ecomuseum at entrance to the Opunohu Valley. (Also perhaps local Associations that might be interested, e.g., Te Pu Atitia). Sampling Nature will produce an outreach videos based on this Island Sampling Day.&lt;/p&gt; </description>
+    </descriptions>
+    <fundingReferences>
+        <fundingReference>
+            <funderName>Genomic Standards Consortium</funderName>
+        </fundingReference>
+    </fundingReferences>
+    <relatedIdentifiers>
+        <relatedIdentifier relationType="IsMetadataFor" relatedIdentifierType="URL"> https://dmptool.org/api/v2/plans/74309.pdf </relatedIdentifier>
+        <relatedIdentifier relationType="Cites" relatedIdentifierType="URL"> https://n2t.net/ark:/21547/EBW2 </relatedIdentifier>
+        <relatedIdentifier relationType="Cites" relatedIdentifierType="URL"> https://docs.google.com/document/d/1EYgEEUroMBiTNc5Px11_44G-B17JtTgyssyNkK3hV_U/edit#heading=h.ckwz8v2yry1q </relatedIdentifier>
+    </relatedIdentifiers>
+</resource>

--- a/spec/readers/datacite_reader_spec.rb
+++ b/spec/readers/datacite_reader_spec.rb
@@ -592,7 +592,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.id).to eq("https://doi.org/10.18429/jacow-ipac2016-tupmy003")
       expect(subject.types["schemaOrg"]).to eq("ScholarlyArticle")
       expect(subject.creators.length).to eq(12)
-      expect(subject.creators.first).to eq("nameType"=>"Personal", "nameIdentifiers" => [{"nameIdentifier"=>"http://jacow.org/JACoW-00077389", "nameIdentifierScheme"=>"JACoW-ID", "schemeUri"=>"http://jacow.org/"}], "name"=>"Otani, Masashi", "givenName"=>"Masashi", "familyName"=>"Otani", "affiliation" => [{"name"=>"KEK, Tsukuba, Japan"}])
+      expect(subject.creators.first).to eq("nameType"=>"Personal", "nameIdentifiers" => [{"nameIdentifier"=>"JACoW-00077389", "nameIdentifierScheme"=>"JACoW-ID", "schemeUri"=>"http://jacow.org/"}], "name"=>"Otani, Masashi", "givenName"=>"Masashi", "familyName"=>"Otani", "affiliation" => [{"name"=>"KEK, Tsukuba, Japan"}])
     end
 
     it "author with wrong orcid scheme" do
@@ -722,7 +722,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.types["ris"]).to eq("BOOK")
       expect(subject.types["citeproc"]).to eq("book")
       expect(subject.creators).to eq([{"nameType"=>"Personal", "name"=>"Smith, John", "givenName"=>"John", "familyName"=>"Smith", "nameIdentifiers" => [], "affiliation" => []}, {"name"=>"つまらないものですが","nameIdentifiers"=>
-        [{"nameIdentifier"=>"http://isni.org/isni/0000000134596520",
+        [{"nameIdentifier"=>"0000000134596520",
           "nameIdentifierScheme"=>"ISNI",
           "schemeUri"=>"http://isni.org/isni/"}],
           "affiliation" => []}])
@@ -753,7 +753,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.types["ris"]).to eq("BOOK")
       expect(subject.types["citeproc"]).to eq("book")
       expect(subject.creators).to eq([{"nameType"=>"Personal", "name"=>"Smith, John", "givenName"=>"John", "familyName"=>"Smith", "nameIdentifiers" => [], "affiliation" => []}, {"name"=>"つまらないものですが","nameIdentifiers"=>
-        [{"nameIdentifier"=>"http://isni.org/isni/0000000134596520",
+        [{"nameIdentifier"=>"0000000134596520",
           "nameIdentifierScheme"=>"ISNI",
           "schemeUri"=>"http://isni.org/isni/"}],
           "affiliation" => []}])
@@ -812,7 +812,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.types["ris"]).to eq("BOOK")
       expect(subject.types["citeproc"]).to eq("book")
       expect(subject.creators).to eq([{"nameType"=>"Personal", "name"=>"Smith, John", "givenName"=>"John", "familyName"=>"Smith", "nameIdentifiers" => [], "affiliation" => []}, {"name"=>"つまらないものですが","nameIdentifiers"=>
-        [{"nameIdentifier"=>"http://isni.org/isni/0000000134596520",
+        [{"nameIdentifier"=>"0000000134596520",
           "nameIdentifierScheme"=>"ISNI",
           "schemeUri"=>"http://isni.org/isni/"}],
           "affiliation" => []}])
@@ -864,7 +864,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.types["resourceType"]).to eq("Monograph")
       expect(subject.types["resourceTypeGeneral"]).to eq("Text")
       expect(subject.creators).to eq([{"nameType"=>"Personal", "name"=>"Smith, John", "givenName"=>"John", "familyName"=>"Smith", "nameIdentifiers" => [], "affiliation" => []}, {"name"=>"つまらないものですが","nameIdentifiers"=>
-        [{"nameIdentifier"=>"http://isni.org/isni/0000000134596520",
+        [{"nameIdentifier"=>"0000000134596520",
           "nameIdentifierScheme"=>"ISNI",
           "schemeUri"=>"http://isni.org/isni/"}],
           "affiliation" => []}])


### PR DESCRIPTION
…enate the schemeURI and the nameIdentifier

Fixes #136

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

When a nameIdentifier property contains both a schemeURI attribute and a nameIdentifier in the form of a URL, bolognese concatenates the schemeURI and nameIdentifier, resulting in incorrectly normalized nameIdentifiers like `https://ror.org/https://ror.org/04p8xrf95 `. This does not affect ORCIDs, which have specific normalization logic applied. 

closes: #136

## Approach
<!--- _How does this change address the problem?_ -->

Rather than simply concatenating schemeURIs and nameIdentifiers when a schemeURI is present, the code now adopts the logic from the affiliationIdentifier code:

https://github.com/datacite/bolognese/blob/5a01ebd48784fa837db351405a8153e1bbb5c18d/lib/bolognese/author_utils.rb#L147

This only concatenates the schemeURI if "https://" is not present in the nameIdentifier and a schemeURI is present. It also performs some additional URL normalization found here:

https://github.com/datacite/bolognese/blob/5a01ebd48784fa837db351405a8153e1bbb5c18d/lib/bolognese/utils.rb#L610

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

Unfortunately, applying this logic to, for example, ISNIs can be problematic. As it currently exists, the implementation fails a test where nameIdentifier `0000 0003 5752 6882` with schemeURI `http://isni.org/isni/` is normalized to `http://isni.org/isni/0000%200003%205752%206882` (with the spaces escaped) when the test expects `http://isni.org/isni/0000 0003 5752 6882`. I would argue that neither the original test nor the fix produce correct results, since the ISNI is correct in the original expression `0000 0003 5752 6882`. 

The available options seem to be:

- Keep the current fix but apply it only to RORs and add ROR-specific logics, e.g. always assume the schemeURI is `https://ror.org/` when the nameIdentifierScheme is `ROR`.  For other identifier schemes, simply transcribe the schemeURI and nameIdentifier as entered. 
- Create additional logics for other identifiers like ISNIs.
- Make no attempt at normalization and leave nameIdentifiers and schemeURIs as entered if they are not ORCIDs. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
