### PR TITLE
Fixes normalization behavior that omitted non-URL funding identifiers when reading from DataCite XML. Adds normalization for Crossref Funder ID and ROR funderIdentifierTypes.

### DIFF
--- a/lib/bolognese/readers/datacite_reader.rb
+++ b/lib/bolognese/readers/datacite_reader.rb
@@ -164,7 +164,7 @@ module Bolognese
             funder_identifier =  normalize_ror(funder_identifier)
             scheme_uri = "https://ror.org"
           else
-            funder_identifier = funder_identifier.to_s.start_with?("https://","http://") ? normalize_id(funder_identifier) : funder_identifier
+            funder_identifier = normalize_id(funder_identifier) ? normalize_id(funder_identifier) : funder_identifier
           end
 
           {

--- a/lib/bolognese/readers/datacite_reader.rb
+++ b/lib/bolognese/readers/datacite_reader.rb
@@ -163,6 +163,8 @@ module Bolognese
           elsif funder_identifier_type == "ROR"
             funder_identifier =  normalize_ror(funder_identifier)
             scheme_uri = "https://ror.org"
+          else
+            funder_identifier = funder_identifier.to_s.start_with?("https://","http://") ? normalize_id(funder_identifier) : funder_identifier
           end
 
           {

--- a/lib/bolognese/readers/datacite_reader.rb
+++ b/lib/bolognese/readers/datacite_reader.rb
@@ -157,14 +157,19 @@ module Bolognese
           scheme_uri = parse_attributes(fr["funderIdentifier"], content: "schemeURI")
           funder_identifier = parse_attributes(fr["funderIdentifier"])
           funder_identifier_type = parse_attributes(fr["funderIdentifier"], content: "funderIdentifierType")
-          if funder_identifier_type != "Other"
-            funder_identifier = !funder_identifier.to_s.start_with?("https://","http://") && scheme_uri.present? ? normalize_id(scheme_uri + funder_identifier) : normalize_id(funder_identifier)
+
+          if funder_identifier_type == "Crossref Funder ID"
+            funder_identifier = validate_funder_doi(funder_identifier)
+          elsif funder_identifier_type == "ROR"
+            funder_identifier =  normalize_ror(funder_identifier)
+            scheme_uri = "https://ror.org"
           end
 
           {
             "funderName" => fr["funderName"],
             "funderIdentifier" => funder_identifier,
             "funderIdentifierType" => funder_identifier_type,
+            "schemeUri" => scheme_uri,
             "awardNumber" => parse_attributes(fr["awardNumber"]),
             "awardUri" => parse_attributes(fr["awardNumber"], content: "awardURI"),
             "awardTitle" => fr["awardTitle"] }.compact

--- a/spec/fixtures/datacite-funderIdentifier.xml
+++ b/spec/fixtures/datacite-funderIdentifier.xml
@@ -59,6 +59,26 @@
       <funderName>European Commission</funderName>
       <funderIdentifier funderIdentifierType="Crossref Funder ID" schemeURI="https://doi.org/">https://doi.org/10.13039/501100000780</funderIdentifier>
     </fundingReference>
+    <fundingReference>
+      <funderName>University of Washington</funderName>
+      <funderIdentifier funderIdentifierType="ISNI" schemeURI="http://www.isni.org/isni/">0000 0001 2298 6657</funderIdentifier>
+    </fundingReference>
+    <fundingReference>
+      <funderName>National Library of Ireland.</funderName>
+      <funderIdentifier funderIdentifierType="Other" schemeURI="http://viaf.org/viaf/">127467345</funderIdentifier>
+    </fundingReference>
+    <fundingReference>
+      <funderName>DataCite</funderName>
+      <funderIdentifier funderIdentifierType="ROR" schemeURI="https://ror.org/">https://ror.org/04wxnsj81</funderIdentifier>
+    </fundingReference>
+    <fundingReference>
+      <funderName>Department of Agriculture</funderName>
+      <funderIdentifier funderIdentifierType="ROR">038wwg650</funderIdentifier>
+    </fundingReference>
+    <fundingReference>
+      <funderName>Tottori University</funderName>
+      <funderIdentifier funderIdentifierType="Crossref Funder ID">10.13039/501100005695</funderIdentifier>
+    </fundingReference>
   </fundingReferences>
   <rightsList>
     <rights xml:lang="eng" rightsURI="http://creativecommons.org/licenses/by-nd/2.0/">Creative Commons

--- a/spec/readers/datacite_reader_spec.rb
+++ b/spec/readers/datacite_reader_spec.rb
@@ -141,6 +141,7 @@ describe Bolognese::Metadata, vcr: true do
         "awardTitle"=>"Full DataCite XML Example",
         "funderIdentifier"=>"https://doi.org/10.13039/100000001",
         "funderIdentifierType"=>"Crossref Funder ID",
+        "schemeUri"=>"https://doi.org/",
         "funderName"=>"National Science Foundation"}])
       expect(subject.related_identifiers.length).to eq(2)
       expect(subject.related_identifiers.first).to eq("relatedIdentifier"=>"https://data.datacite.org/application/citeproc+json/10.5072/example-full", "relatedIdentifierType"=>"URL", "relationType"=>"HasMetadata", "relatedMetadataScheme"=>"citeproc+json", "schemeUri"=>"https://github.com/citation-style-language/schema/raw/master/csl-data.json")
@@ -420,15 +421,46 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.funding_references.first).to eq({
         "funderIdentifier"=>"http://www.isni.org/isni/0000000119587073",
         "funderIdentifierType"=>"ISNI",
+        "schemeUri"=>"http://www.isni.org/isni/",
         "funderName"=>"National Science Foundation (NSF)"})
-      expect(subject.funding_references.last).to eq({
+      expect(subject.funding_references[2]).to eq({
         "funderIdentifier"=>"https://doi.org/10.13039/501100000780",
         "funderIdentifierType"=>"Crossref Funder ID",
+        "schemeUri"=>"https://doi.org/",
         "funderName"=>"European Commission"})
       expect(subject.funding_references[1]).to eq({
           "funderIdentifier"=>"1234",
           "funderIdentifierType"=>"Other",
           "funderName"=>"Acme Inc"})
+    end
+
+    it "funder identifier with normalized identifiers and non-normalized identifiers" do
+      input = fixture_path + 'datacite-funderIdentifier.xml'
+      subject = Bolognese::Metadata.new(input: input)
+      expect(subject.funding_references[3]).to eq({
+        "funderIdentifier"=>"0000 0001 2298 6657",
+        "funderIdentifierType"=>"ISNI",
+        "schemeUri"=>"http://www.isni.org/isni/",
+        "funderName"=>"University of Washington"})
+      expect(subject.funding_references[4]).to eq({
+        "funderIdentifier"=>"127467345",
+        "funderIdentifierType"=>"Other",
+        "schemeUri"=>"http://viaf.org/viaf/",
+        "funderName"=>"National Library of Ireland."})
+      expect(subject.funding_references[5]).to eq({
+          "funderIdentifier"=>"https://ror.org/04wxnsj81",
+          "funderIdentifierType"=>"ROR",
+          "schemeUri"=>"https://ror.org",
+          "funderName"=>"DataCite"})
+      expect(subject.funding_references[6]).to eq({
+          "funderIdentifier"=>"https://ror.org/038wwg650",
+          "funderIdentifierType"=>"ROR",
+          "schemeUri"=>"https://ror.org",
+          "funderName"=>"Department of Agriculture"})
+      expect(subject.funding_references[7]).to eq({
+        "funderIdentifier"=>"https://doi.org/10.13039/501100005695",
+        "funderIdentifierType"=>"Crossref Funder ID",
+        "funderName"=>"Tottori University"})
     end
 
     it "geo_location empty" do


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

When reading DataCite XML, bolognese would not return the funder identifier in a funding reference if the funder identifier did not originally appear as a URL. 

closes: #142 

## Approach
<!--- _How does this change address the problem?_ -->

When processing `funding_references`, a normalization step would attempt to render the `funder_identifier` as a URL: 

https://github.com/datacite/bolognese/blob/dc8170d2f44271bc20a9c649c10130422007a4bf/lib/bolognese/readers/datacite_reader.rb#L161

If the schemeURI was present, `normalize_id` would be called on a concatenation of the schemeURI and funder identifier. Otherwise, `normalize_id` would be called on the funder identifier. If `normalize_id` could not render either as a URI, `funder_identifier` would become nil: 

https://github.com/datacite/bolognese/blob/dc8170d2f44271bc20a9c649c10130422007a4bf/lib/bolognese/utils.rb#L614

This PR normalizes Crossref Funder IDs and RORs but performs no normalization steps otherwise, avoiding a `funder_identifier` nil value. It also adds the optional `schemeUri` attribute to the rendered funding reference, which was originally not included. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

- [ ] Does including schemeUri here have any downstream issues?
- [ ] What changes in lupo are necessary to properly import and index fundingReference schemeUris? 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
