### PR TITLE
Fractional date bug 1361

### DIFF
--- a/lib/bolognese/readers/datacite_reader.rb
+++ b/lib/bolognese/readers/datacite_reader.rb
@@ -125,11 +125,15 @@ module Bolognese
 
         dates = Array.wrap(meta.dig("dates", "date")).map do |r|
           if r.is_a?(Hash) && date = sanitize(r["__content__"]).presence
-            if Date.edtf(date).present? || Bolognese::Utils::UNKNOWN_INFORMATION.key?(date)
-              { "date" => date,
-                "dateType" => parse_attributes(r, content: "dateType"),
-                "dateInformation" => parse_attributes(r, content: "dateInformation")
-              }.compact
+            begin
+              if Date.edtf(date).present? || Bolognese::Utils::UNKNOWN_INFORMATION.key?(date) || Time.iso8601(date).present?
+                { "date" => date,
+                  "dateType" => parse_attributes(r, content: "dateType"),
+                  "dateInformation" => parse_attributes(r, content: "dateInformation")
+                }.compact
+              end
+            rescue
+              nil
             end
           end
         end.compact

--- a/spec/fixtures/datacite-example-fractional-date.xml
+++ b/spec/fixtures/datacite-example-fractional-date.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.4/metadata.xsd">
+  <identifier identifierType="DOI">10.5072/example-fractional-date</identifier>
+  <creators>
+        <creator>
+            <creatorName>Claire L O?Brien</creatorName>
+        </creator>
+    </creators>
+    <titles>
+        <title>Impact of Colonoscopy Bowel Preparation on Intestinal Microbiota</title>
+    </titles>
+    <dates>
+        <date dateType="Updated">2020-11-06T21:37:33.12Z</date>
+    </dates>
+    <publisher>The Australian National University Data Commons</publisher>
+    <publicationYear>2013</publicationYear>
+      <rightsList>
+    <rights xml:lang="en-US" schemeURI="https://spdx.org/licenses/" rightsIdentifierScheme="SPDX" rightsIdentifier="CC0 1.0" rightsURI="http://creativecommons.org/publicdomain/zero/1.0/"/>
+  </rightsList>
+    <language>en</language>
+  <resourceType resourceTypeGeneral="Dissertation"></resourceType>
+</resource>

--- a/spec/readers/datacite_reader_spec.rb
+++ b/spec/readers/datacite_reader_spec.rb
@@ -1653,4 +1653,12 @@ describe Bolognese::Metadata, vcr: true do
     )
   end
 
+  it "Parses dates with fractional seconds" do
+    input = fixture_path + "datacite-example-fractional-date.xml"
+    subject = Bolognese::Metadata.new(input: input)
+    expect(subject.valid?).to be true
+    expect(subject.dates).to eq([{"date"=>"2020-11-06T21:37:33.12Z", "dateType"=>"Updated"}, {"date"=>"2013", "dateType"=>"Issued"}])
+  end
+
+
 end


### PR DESCRIPTION
## Purpose
Fixed issue where dates with fractional times wouldn't be returned from API

closes: https://github.com/datacite/datacite/issues/1361

## Approach
Added Time.iso8601 to handle fractional times

#### Open Questions and Pre-Merge TODOs

## Learning
Researched different ways to handle parsing dates with fractional times according to the schema. Found a [class](https://docs.ruby-lang.org/en/2.1.0/Time.html#method-c-w3cdtf) which looked promising, but ended up not being supported for the version ruby we're using. After a bit more research I settled on using the Time.iso8601 method.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
