### PR TITLE
Fix using non abstract descriptions when writing ris/schemaorg

### DIFF
--- a/lib/bolognese/metadata.rb
+++ b/lib/bolognese/metadata.rb
@@ -156,6 +156,11 @@ module Bolognese
       @descriptions ||= meta.fetch("descriptions", nil)
     end
 
+    def abstract_description
+      # Fetch the first description with descriptionType "Abstract"
+      @abstract_description ||= descriptions&.find { |d| d["descriptionType"] == "Abstract" }
+    end
+
     def rights_list
       @rights_list ||= meta.fetch("rights_list", nil)
     end

--- a/lib/bolognese/writers/ris_writer.rb
+++ b/lib/bolognese/writers/ris_writer.rb
@@ -11,7 +11,7 @@ module Bolognese
           "AU" => to_ris(creators),
           "DO" => doi,
           "UR" => url,
-          "AB" => parse_attributes(descriptions, content: "description", first: true),
+          "AB" => parse_attributes(abstract_description, content: "description", first: true),
           "KW" => Array.wrap(subjects).map { |k| parse_attributes(k, content: "subject", first: true) }.presence,
           "PY" => publication_year,
           "PB" => publisher,

--- a/lib/bolognese/writers/schema_org_writer.rb
+++ b/lib/bolognese/writers/schema_org_writer.rb
@@ -13,7 +13,7 @@ module Bolognese
           "name" => parse_attributes(titles, content: "title", first: true),
           "author" => to_schema_org_creators(creators),
           "editor" => to_schema_org_contributors(contributors),
-          "description" => parse_attributes(descriptions, content: "description", first: true),
+          "description" => parse_attributes(abstract_description, content: "description", first: true),
           "license" => Array.wrap(rights_list).map { |l| l["rightsUri"] }.compact.unwrap,
           "version" => version_info,
           "keywords" => subjects.present? ? Array.wrap(subjects).map { |k| parse_attributes(k, content: "subject", first: true) }.join(", ") : nil,

--- a/spec/fixtures/datacite.json
+++ b/spec/fixtures/datacite.json
@@ -43,7 +43,7 @@
     }
   ],
   "dates": [
-    { 
+    {
       "dateType": "Created",
       "date": "2016-12-20"
     },
@@ -74,10 +74,16 @@
     }
   ],
   "version": "1.0",
-  "descriptions": [{
+  "descriptions": [
+    {
+      "descriptionType": "SeriesInformation",
+      "description": "Volume(1) Series(3)"
+    },
+    {
     "descriptionType": "Abstract",
     "description": "Eating your own dog food is a slang term to describe that an organization should itself use the products and services it provides. For DataCite this means that we should use DOIs with appropriate metadata and strategies for long-term preservation for..."
-  }],
+    }
+  ],
   "schemaVersion": "http://datacite.org/schema/kernel-4",
   "agency": "datacite"
 }


### PR DESCRIPTION
This is because a lot of metadata can contain descriptions i.e. series information that while useful is better output in other places.

Therefore for RIS and SchemaOrg better to just write out the ones we find for Abstract types

## Purpose
To fix a bug

closes: datacite/datacite#1294

## Approach
Add new abstract_description dynamic attribute

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
