### PR TITLE
Add fix for missing name in citeproc with literal

### DIFF
--- a/lib/bolognese/utils.rb
+++ b/lib/bolognese/utils.rb
@@ -1021,7 +1021,7 @@ module Bolognese
       Array.wrap(element).map do |a|
         if a["literal"].present?
           a["@type"] = "Organization"
-          a["name"] = a["literal"]
+          a["creatorName"] = a["literal"]
         else
           a["@type"] = "Person"
           a["name"] = [a["given"], a["family"]].compact.join(" ")

--- a/spec/fixtures/citeproc.json
+++ b/spec/fixtures/citeproc.json
@@ -25,6 +25,8 @@
     },
     "author": [{
         "family": "Fenner",
-        "given": "Martin"
-    }]
+        "given": "Martin",
+        "literal": "Fenner, Martin"
+    }
+]
 }


### PR DESCRIPTION
When parsing citeproc use creatorName instead of Name, this will then get parsed correctly.

## Purpose
closes: datacite/datacite#1765

## Approach
The author parsing is very complicated and prone to error, without getting into the weeds, the easiest method to ensure a literal can be parsed (and therefore is same as our writer) is to set creatorName this then will be used when writing out various formats.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
