### PR TITLE
Issue-152 Enhancement: Update Method to Preserve Non-URL Affiliation …

### DIFF
--- a/lib/bolognese/author_utils.rb
+++ b/lib/bolognese/author_utils.rb
@@ -154,9 +154,14 @@ module Bolognese
             # The normalize_id(affiliation_identifier) method currently discards affiliation identifiers that don't start with a URL, 
             # for example: affiliation_identifier = "05bp8ka05".
             # To address this issue, we are introducing the following change to handle such affiliation identifiers.
-            if a["affiliationIdentifierScheme"] == "ROR" && affiliation_identifier.nil?
-              scheme_uri = "https://ror.org"
-              affiliation_identifier = scheme_uri + "/" + a["affiliationIdentifier"]
+            # when `normalize_id` method could not normalize, it returns nil, hence we have following condition
+            if affiliation_identifier.nil?
+              if a["affiliationIdentifierScheme"] == "ROR"
+                scheme_uri = "https://ror.org"
+                affiliation_identifier = normalize_ror(a["affiliationIdentifier"])
+              else
+                affiliation_identifier = a["affiliationIdentifier"]
+              end
             end
           end
           name = a["__content__"].to_s.squish.presence

--- a/lib/bolognese/author_utils.rb
+++ b/lib/bolognese/author_utils.rb
@@ -144,16 +144,23 @@ module Bolognese
           affiliation_identifier_scheme = nil
           scheme_uri = nil
         else
+          scheme_uri = a["schemeURI"]
           if a["affiliationIdentifier"].present?
             affiliation_identifier = a["affiliationIdentifier"]
             if a["schemeURI"].present?
               schemeURI = a["schemeURI"].end_with?("/") ? a["schemeURI"] : a["schemeURI"] + "/"
             end
             affiliation_identifier = !affiliation_identifier.to_s.start_with?("https://") && schemeURI.present? ? normalize_id(schemeURI + affiliation_identifier) : normalize_id(affiliation_identifier)
+            # The normalize_id(affiliation_identifier) method currently discards affiliation identifiers that don't start with a URL, 
+            # for example: affiliation_identifier = "05bp8ka05".
+            # To address this issue, we are introducing the following change to handle such affiliation identifiers.
+            if a["affiliationIdentifierScheme"] == "ROR" && affiliation_identifier.nil?
+              scheme_uri = "https://ror.org"
+              affiliation_identifier = scheme_uri + "/" + a["affiliationIdentifier"]
+            end
           end
           name = a["__content__"].to_s.squish.presence
           affiliation_identifier_scheme = a["affiliationIdentifierScheme"]
-          scheme_uri = a["SchemeURI"]
         end
 
         { "name" => name,

--- a/spec/author_utils_spec.rb
+++ b/spec/author_utils_spec.rb
@@ -163,13 +163,24 @@ describe Bolognese::Metadata, vcr: true do
   it "has ROR nameIdentifiers" do
     input = fixture_path + 'datacite-example-ROR-nameIdentifiers.xml'
     subject = Bolognese::Metadata.new(input: input, from: "datacite")
-    expect(subject.creators[1]).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
-    expect(subject.creators[2]).to eq("nameType"=>"Organizational", "name"=>"University Of Vic", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/006zjws59", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
-    expect(subject.creators[3]).to eq("nameType"=>"Organizational", "name"=>"University Of Kivu", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/01qfhxr31", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
-    expect(subject.creators[4]).to eq("nameType"=>"Organizational", "name"=>"សាកលវិទ្យាល័យកម្ពុជា", "nameIdentifiers"=> [{"nameIdentifier"=>"http://ror.org/025e3rc84", "nameIdentifierScheme"=>"RORS"}], "affiliation"=>[])
-    expect(subject.creators[5]).to eq("nameType"=>"Organizational", "name"=>"جامعة زاخۆ", "nameIdentifiers"=> [{"nameIdentifier"=>"05sd1pz50", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"RORS"}], "affiliation"=>[])
+    expect(subject.creators[2]).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
+    expect(subject.creators[3]).to eq("nameType"=>"Organizational", "name"=>"University Of Vic", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/006zjws59", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
+    expect(subject.creators[4]).to eq("nameType"=>"Organizational", "name"=>"University Of Kivu", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/01qfhxr31", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
+    expect(subject.creators[5]).to eq("nameType"=>"Organizational", "name"=>"សាកលវិទ្យាល័យកម្ពុជា", "nameIdentifiers"=> [{"nameIdentifier"=>"http://ror.org/025e3rc84", "nameIdentifierScheme"=>"RORS"}], "affiliation"=>[])
+    expect(subject.creators[6]).to eq("nameType"=>"Organizational", "name"=>"جامعة زاخۆ", "nameIdentifiers"=> [{"nameIdentifier"=>"05sd1pz50", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"RORS"}], "affiliation"=>[])
     expect(subject.contributors.first).to eq("nameType"=>"Organizational", "name"=>" Nawroz University ", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04gp75d48", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[], "contributorType"=>"Producer")
     expect(subject.contributors.last).to eq("nameType"=>"Organizational", "name"=>"University Of Greenland (Https://Www.Uni.Gl/)", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/00t5j6b61", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}],"affiliation"=>[], "contributorType"=>"Sponsor")
+  end
+
+  context "has ROR affiliationIdentifier" do
+    it "should parse affiliationIdentifier with and without URL" do
+      input = fixture_path + 'datacite-example-ROR-nameIdentifiers.xml'
+      subject = Bolognese::Metadata.new(input: input, from: "datacite")
+      # without URL inside affiliationIdentifier="05bp8ka77"
+      expect(subject.creators[0]).to eq({"nameType"=>"Personal", "name"=>"Sukale, Ashwini", "givenName"=>"Ashwini", "familyName"=>"Sukale", "nameIdentifiers"=>[{"schemeUri"=>"https://orcid.org", "nameIdentifierScheme"=>"ORCID"}], "affiliation"=>[{"name"=>"Metadata Game Changers", "affiliationIdentifier"=>"https://ror.org/05bp8ka77", "affiliationIdentifierScheme"=>"ROR", "schemeUri"=>"https://ror.org"}]})
+      # with URL "affiliationIdentifier"=>"https://ror.org/05bp8ka05"
+      expect(subject.creators[1]).to eq({"nameType"=>"Personal", "name"=>"Robinson, Erin", "givenName"=>"Erin", "familyName"=>"Robinson", "nameIdentifiers"=>[{"schemeUri"=>"https://orcid.org", "nameIdentifierScheme"=>"ORCID"}], "affiliation"=>[{"name"=>"Metadata Game Changers", "affiliationIdentifier"=>"https://ror.org/05bp8ka05", "affiliationIdentifierScheme"=>"ROR", "schemeUri"=>"https://ror.org"}]})
+    end
   end
 
   context "authors_as_string" do

--- a/spec/author_utils_spec.rb
+++ b/spec/author_utils_spec.rb
@@ -172,14 +172,27 @@ describe Bolognese::Metadata, vcr: true do
     expect(subject.contributors.last).to eq("nameType"=>"Organizational", "name"=>"University Of Greenland (Https://Www.Uni.Gl/)", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/00t5j6b61", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}],"affiliation"=>[], "contributorType"=>"Sponsor")
   end
 
-  context "has ROR affiliationIdentifier" do
-    it "should parse affiliationIdentifier with and without URL" do
+  context "affiliationIdentifier" do
+    it "should normalize ROR affiliationIdentifier with and without URL" do
       input = fixture_path + 'datacite-example-ROR-nameIdentifiers.xml'
       subject = Bolognese::Metadata.new(input: input, from: "datacite")
       # without URL inside affiliationIdentifier="05bp8ka77"
-      expect(subject.creators[0]).to eq({"nameType"=>"Personal", "name"=>"Sukale, Ashwini", "givenName"=>"Ashwini", "familyName"=>"Sukale", "nameIdentifiers"=>[{"schemeUri"=>"https://orcid.org", "nameIdentifierScheme"=>"ORCID"}], "affiliation"=>[{"name"=>"Metadata Game Changers", "affiliationIdentifier"=>"https://ror.org/05bp8ka77", "affiliationIdentifierScheme"=>"ROR", "schemeUri"=>"https://ror.org"}]})
+      ror_affiliater0 = subject.creators[0]["affiliation"].select { |r| r["affiliationIdentifierScheme"] == "ROR" }
+      expect(ror_affiliater0[0]["affiliationIdentifier"]).to eq("https://ror.org/05bp8ka77")
       # with URL "affiliationIdentifier"=>"https://ror.org/05bp8ka05"
-      expect(subject.creators[1]).to eq({"nameType"=>"Personal", "name"=>"Robinson, Erin", "givenName"=>"Erin", "familyName"=>"Robinson", "nameIdentifiers"=>[{"schemeUri"=>"https://orcid.org", "nameIdentifierScheme"=>"ORCID"}], "affiliation"=>[{"name"=>"Metadata Game Changers", "affiliationIdentifier"=>"https://ror.org/05bp8ka05", "affiliationIdentifierScheme"=>"ROR", "schemeUri"=>"https://ror.org"}]})
+      ror_affiliater1 = subject.creators[1]["affiliation"].select { |r| r["affiliationIdentifierScheme"] == "ROR" }
+      expect(ror_affiliater1[0]["affiliationIdentifier"]).to eq("https://ror.org/05bp8ka05")
+    end
+
+    it "should parse non ROR schema's without normalizing them" do
+      input = fixture_path + 'datacite-example-ROR-nameIdentifiers.xml'
+      subject = Bolognese::Metadata.new(input: input, from: "datacite")
+      # without "schemeURI"
+      grid_affiliater0 = subject.creators[0]["affiliation"].select { |r| r["affiliationIdentifierScheme"] == "GRID" }
+      expect(grid_affiliater0[0]["affiliationIdentifier"]).to eq("grid.268117.b")
+      # with "schemeURI"=>"https://grid.ac/institutes/"
+      grid_affiliater1 = subject.creators[1]["affiliation"].select { |r| r["affiliationIdentifierScheme"] == "GRID" }
+      expect(grid_affiliater1[0]["affiliationIdentifier"]).to eq("https://grid.ac/institutes/grid.268117.b")
     end
   end
 

--- a/spec/fixtures/datacite-example-ROR-nameIdentifiers.xml
+++ b/spec/fixtures/datacite-example-ROR-nameIdentifiers.xml
@@ -7,11 +7,13 @@
             <creatorName nameType="Personal">Ashwini Sukale</creatorName>
             <nameIdentifier schemeURI="https://orcid.org/" nameIdentifierScheme="ORCID"> https://orcid.org/0000-0001-9998-0117 </nameIdentifier>
             <affiliation affiliationIdentifier="05bp8ka77" affiliationIdentifierScheme="ROR"> Metadata Game Changers </affiliation>
+            <affiliation affiliationIdentifier="grid.268117.b" affiliationIdentifierScheme="GRID">Wesleyan University</affiliation>
         </creator>
         <creator>
             <creatorName nameType="Personal">Erin Robinson</creatorName>
             <nameIdentifier schemeURI="https://orcid.org/" nameIdentifierScheme="ORCID"> https://orcid.org/0000-0001-9998-0114 </nameIdentifier>
             <affiliation schemeURI="https://ror.org" affiliationIdentifier="https://ror.org/05bp8ka05" affiliationIdentifierScheme="ROR"> Metadata Game Changers </affiliation>
+            <affiliation affiliationIdentifier="grid.268117.b" affiliationIdentifierScheme="GRID" schemeURI="https://grid.ac/institutes/">Wesleyan University</affiliation>
         </creator>
         <creator>
             <creatorName nameType="Organizational">Gump South Pacific Research Station</creatorName>

--- a/spec/fixtures/datacite-example-ROR-nameIdentifiers.xml
+++ b/spec/fixtures/datacite-example-ROR-nameIdentifiers.xml
@@ -4,6 +4,11 @@
     <identifier identifierType="DOI">10.48321/D1Z60Q</identifier>
     <creators>
         <creator>
+            <creatorName nameType="Personal">Ashwini Sukale</creatorName>
+            <nameIdentifier schemeURI="https://orcid.org/" nameIdentifierScheme="ORCID"> https://orcid.org/0000-0001-9998-0117 </nameIdentifier>
+            <affiliation affiliationIdentifier="05bp8ka77" affiliationIdentifierScheme="ROR"> Metadata Game Changers </affiliation>
+        </creator>
+        <creator>
             <creatorName nameType="Personal">Erin Robinson</creatorName>
             <nameIdentifier schemeURI="https://orcid.org/" nameIdentifierScheme="ORCID"> https://orcid.org/0000-0001-9998-0114 </nameIdentifier>
             <affiliation schemeURI="https://ror.org" affiliationIdentifier="https://ror.org/05bp8ka05" affiliationIdentifierScheme="ROR"> Metadata Game Changers </affiliation>

--- a/spec/readers/datacite_reader_spec.rb
+++ b/spec/readers/datacite_reader_spec.rb
@@ -121,7 +121,7 @@ describe Bolognese::Metadata, vcr: true do
         "name"=>"Brown University"},
        {"affiliationIdentifier"=>"https://grid.ac/institutes/grid.268117.b",
         "affiliationIdentifierScheme"=>"GRID",
-        "name"=>"Wesleyan University"}])
+        "name"=>"Wesleyan University", "schemeUri"=>"https://grid.ac/institutes/"}])
       expect(subject.creators.dig(2, "affiliation")).to eq([{"affiliationIdentifier"=>"https://ror.org/05gq02987",
         "affiliationIdentifierScheme"=>"ROR", "name"=>"Brown University"}])
       expect(subject.titles).to eq([{"lang"=>"en-US", "title"=>"Full DataCite XML Example"}, {"lang"=>"en-US", "title"=>"Demonstration of DataCite Properties.", "titleType"=>"Subtitle"}])
@@ -950,7 +950,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.types["ris"]).to eq("DATA")
       expect(subject.types["bibtex"]).to eq("misc")
       expect(subject.creators.length).to eq(1)
-      expect(subject.creators.first).to eq("affiliation" => [{"affiliationIdentifier"=>"https://ror.org/04zt3wx35", "affiliationIdentifierScheme"=>"ROR", "name"=>"Canada Mortgage and Housing Corporation"}],
+      expect(subject.creators.first).to eq("affiliation" => [{"affiliationIdentifier"=>"https://ror.org/04zt3wx35", "affiliationIdentifierScheme"=>"ROR", "name"=>"Canada Mortgage and Housing Corporation", "schemeUri"=>"https://ror.org"}],
         "name" => "Statistique Canada",
          "nameIdentifiers" => [],
         "nameType" => "Organizational")


### PR DESCRIPTION
## Purpose

Preserve Non-URL Affiliation Identifiers for example: `affiliation_identifier = "05bp8ka05".`

closes: https://github.com/datacite/bolognese/issues/152

## Approach
<!--- _How does this change address the problem?_ -->
**Root Cause:** 
The problem arises during the normalization of affiliation identifiers. Currently, the normalization process checks if an identifier is a URL. If it's not a URL, the process returns nil, resulting in the removal of affiliation identifiers that do not start with a URL.
https://github.com/datacite/bolognese/blob/b0a7df3c9dd6a45eaf56fd0e06d304e4db9b837d/lib/bolognese/utils.rb#L649 

**Solution:**
Modifying the `normalize_id` method, which is used in multiple places, is not feasible due to its widespread use. However, since this issue specifically pertains to the `affiliation_identifier`, we have introduced a modification within the `get_affiliations` method to address this particular scenario.

Inside `get_affiliations` method we added if statement which will check if the identifier is present and its not URL then create a value for that identifier explicitly. 

**How to reproduce locally:**  
I have added detailed explanation here.
https://github.com/datacite/bolognese/issues/152#issuecomment-1729422712

**Another minor fix added here while fixing the original issue:**
`scheme_uri = a["SchemeURI"]` here character `S` was capital, and XML metadata file contains the small case. Because of which `scheme_uri` was getting returned in the response for some properties.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
