### PR TITLE
Fix workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,17 +7,3 @@ on:
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
-#  build:
-#    needs: ci
-#    runs-on: ubuntu-latest
-#    env:
-#      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#    steps:
-#    - name: Notify Slack
-#      uses: adamkdean/simple-slack-notify@1.0.4
-#      with:
-#        channel: '#ops'
-#        username: 'GitHub Actions'
-#        color: 'good'
-#        text: 'A new version of the bolognese gem is ready for release.'
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,17 +7,17 @@ on:
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
-  build:
-    needs: ci
-    runs-on: ubuntu-latest
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-    steps:
-    - name: Notify Slack
-      uses: adamkdean/simple-slack-notify@1.0.4
-      with:
-        channel: '#ops'
-        username: 'GitHub Actions'
-        color: 'good'
-        text: 'A new version of the bolognese gem is ready for release.'
+#  build:
+#    needs: ci
+#    runs-on: ubuntu-latest
+#    env:
+#      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#    steps:
+#    - name: Notify Slack
+#      uses: adamkdean/simple-slack-notify@1.0.4
+#      with:
+#        channel: '#ops'
+#        username: 'GitHub Actions'
+#        color: 'good'
+#        text: 'A new version of the bolognese gem is ready for release.'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
   build:
     needs: ci
     runs-on: ubuntu-latest
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+ #   env:
+ #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby 2.6
@@ -33,10 +33,10 @@ jobs:
       env:
         GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
 
-    - name: Notify Slack
-      uses: adamkdean/simple-slack-notify@1.0.4
-      with:
-        channel: '#ops'
-        username: 'GitHub Actions'
-        color: 'good'
-        text: 'A new version of the bolognese gem has been released.'
+#    - name: Notify Slack
+#      uses: adamkdean/simple-slack-notify@1.0.4
+#      with:
+#        channel: '#ops'
+#        username: 'GitHub Actions'
+#        color: 'good'
+#        text: 'A new version of the bolognese gem has been released.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ jobs:
   build:
     needs: ci
     runs-on: ubuntu-latest
- #   env:
- #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby 2.6
@@ -32,11 +30,3 @@ jobs:
         gem push *.gem
       env:
         GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
-
-#    - name: Notify Slack
-#      uses: adamkdean/simple-slack-notify@1.0.4
-#      with:
-#        channel: '#ops'
-#        username: 'GitHub Actions'
-#        color: 'good'
-#        text: 'A new version of the bolognese gem has been released.'


### PR DESCRIPTION
The old slack webhook url has finally been removed and is 404ing rather than just silently failing. Since we get notifications from the Slack/Github integration anyway, this PR removes the broken parts of the workflow.

Although the `build.yml` workflow now does nothing but run the CI workflow, I have left it in place because a) we might want to do other things just in the build process in the future, and b) this is what the PR workflow doeds as well (https://github.com/datacite/bolognese/blob/master/.github/workflows/pull-request.yml)