### PR TITLE
Fix for error when reading blank `nameIdentifier` property from DataCite XML

### DIFF
--- a/lib/bolognese/author_utils.rb
+++ b/lib/bolognese/author_utils.rb
@@ -30,20 +30,20 @@ module Bolognese
       name_type = parse_attributes(author.fetch("creatorName", nil), content: "nameType", first: true) || parse_attributes(author.fetch("contributorName", nil), content: "nameType", first: true)
 
       name_identifiers = Array.wrap(author.fetch("nameIdentifier", nil)).map do |ni|
-        ni["__content__"] = ni["__content__"].strip
+        name_identifier = ni["__content__"].strip if ni["__content__"].present?
         if ni["nameIdentifierScheme"] == "ORCID"
           {
-            "nameIdentifier" => normalize_orcid(ni["__content__"]),
+            "nameIdentifier" => normalize_orcid(name_identifier),
             "schemeUri" => "https://orcid.org",
             "nameIdentifierScheme" => "ORCID" }.compact
         elsif ni["nameIdentifierScheme"] == "ROR"
           {
-            "nameIdentifier" => normalize_ror(ni["__content__"]),
+            "nameIdentifier" => normalize_ror(name_identifier),
             "schemeUri" => "https://ror.org",
             "nameIdentifierScheme" => "ROR" }.compact
         else
           {
-            "nameIdentifier" => ni["__content__"],
+            "nameIdentifier" => name_identifier,
             "schemeUri" => ni.fetch("schemeURI", nil),
             "nameIdentifierScheme" => ni["nameIdentifierScheme"] }.compact
         end

--- a/spec/fixtures/datacite_blank_name_identifier.xml
+++ b/spec/fixtures/datacite_blank_name_identifier.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://schema.datacite.org/meta/kernel-4.3/metadata.xsd">
+  <identifier identifierType="DOI">10.15148/3b68dac4-7688-4fbb-ba64-5f9b3bbab954</identifier>
+  <creators>
+    <creator>
+      <creatorName>SNO KARST</creatorName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org"/>
+    </creator>
+  </creators>
+  <publisher>OSU OREME</publisher>
+  <titles>
+    <title>Time series of type chemistry in Le Tarn basin - PARC NATIONAL CEVENNES observatory - KARST observatory network -  OZCAR Critical Zone network Research Infrastructure</title>
+  </titles>
+  <publicationYear>2023</publicationYear>
+  <contributors>
+    <contributor contributorType="ProjectMember">
+      <contributorName>Manche, Yannick</contributorName>
+      <nameIdentifier schemeURI="http://orcid.org/" nameIdentifierScheme="ORCID"></nameIdentifier>
+    </contributor>
+  </contributors>
+  <resourceType resourceTypeGeneral="Dataset">Dataset</resourceType>
+</resource>

--- a/spec/readers/datacite_reader_spec.rb
+++ b/spec/readers/datacite_reader_spec.rb
@@ -1759,4 +1759,46 @@ describe Bolognese::Metadata, vcr: true do
       )
     end
   end
+
+  it "blank nameIdentifier" do
+    input = fixture_path + "datacite_blank_name_identifier.xml"
+    subject = Bolognese::Metadata.new(input: input)
+    expect(subject.creators).to eq(
+      [
+        {
+          "nameType" => "Personal",
+          "name" => "KARST, SNO",
+          "givenName" => "SNO",
+          "familyName" => "KARST",
+          "nameIdentifiers" =>
+            [
+              {
+                "schemeUri" => "https://orcid.org",
+                "nameIdentifierScheme" => "ORCID"
+              }
+            ],
+          "affiliation" => []
+        }
+      ]
+    )
+    expect(subject.contributors).to eq(
+      [
+        {
+          "nameType" => "Personal",
+          "name" => "Manche, Yannick",
+          "givenName" => "Yannick",
+          "familyName" => "Manche",
+          "nameIdentifiers" =>
+            [
+              {
+                "schemeUri" => "https://orcid.org",
+                "nameIdentifierScheme" => "ORCID"
+              }
+            ],
+          "affiliation" => [],
+          "contributorType" => "ProjectMember"
+        }
+      ]
+    )
+  end
 end


### PR DESCRIPTION
Fixes #177

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Reading from blank `nameIdentifier` properties in DataCite XML was causing NoMethodErrors and consequently downstream issues like datacite/datacite#1970

closes: #177 

## Approach
<!--- _How does this change address the problem?_ -->

Checks for `nameIdentifier` content for presence before stripping.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
