### PR TITLE
Fix for `NoMethodError` when reading blank publisher properties from DataCite XML 

### DIFF
--- a/lib/bolognese/readers/datacite_reader.rb
+++ b/lib/bolognese/readers/datacite_reader.rb
@@ -101,7 +101,7 @@ module Bolognese
             { "name" => r.strip }
           elsif r.is_a?(Hash)
             {
-              "name" => r["__content__"].strip,
+              "name" => r["__content__"].present? ? r["__content__"].strip : nil,
               "publisherIdentifier" => r["publisherIdentifierScheme"] == "ROR" ? normalize_ror(r["publisherIdentifier"]) : r["publisherIdentifier"],
               "publisherIdentifierScheme" => r["publisherIdentifierScheme"],
               "schemeUri" => r["schemeURI"],

--- a/spec/fixtures/datacite_blank_publisher.xml
+++ b/spec/fixtures/datacite_blank_publisher.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+  <identifier identifierType="DOI">10.81360/4DVP-KR57</identifier>
+  <creators>
+    <creator>
+      <creatorName nameType="Personal">Møller, Jørgen</creatorName>
+      <givenName>Jørgen</givenName>
+      <familyName>Møller</familyName>
+    </creator>
+  </creators>
+  <titles>
+    <title xml:lang="en">Economic Crisis and Democratic Breakdown in the Interwar Years: A Reassessment</title>
+    <title xml:lang="de">Wirtschaftskrise und demokratischer Zusammenbruch in der Zwischenkriegszeit: Eine Neubewertung</title>
+  </titles>
+  <publisher publisherIdentifier="https://ror.org/04wxnsj81"></publisher>
+  <publicationYear>2015</publicationYear>
+  <resourceType resourceTypeGeneral="JournalArticle"/>
+</resource>

--- a/spec/readers/datacite_reader_spec.rb
+++ b/spec/readers/datacite_reader_spec.rb
@@ -1801,4 +1801,12 @@ describe Bolognese::Metadata, vcr: true do
       ]
     )
   end
+
+  it "blank publisher" do
+    input = fixture_path + "datacite_blank_publisher.xml"
+    subject = Bolognese::Metadata.new(input: input)
+    expect(subject.publisher).to eq(
+      { "publisherIdentifier" => "https://ror.org/04wxnsj81" }
+    )
+  end
 end


### PR DESCRIPTION
Fixes #180

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Blank publisher properties were causing a `NoMethodError` when being read from DataCite XML. 

closes: #180 

## Approach
<!--- _How does this change address the problem?_ -->

Checks for a `"__content__"` value before stripping the value. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
