### PR TITLE
Fix for rendering of `container_title` as a hash in citations for DOIs with citeproc type `article-journal`

### DIFF
--- a/lib/bolognese/metadata_utils.rb
+++ b/lib/bolognese/metadata_utils.rb
@@ -96,7 +96,7 @@ module Bolognese
       if container.present?
         container["title"]
       elsif types["citeproc"] == "article-journal"
-        publisher
+        publisher["name"] if publisher.present?
       else
         nil
       end

--- a/spec/fixtures/datacite_journal_article.xml
+++ b/spec/fixtures/datacite_journal_article.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+    <identifier identifierType="DOI">10.60843/5EGY-VC42</identifier>
+    <creators>
+        <creator>
+            <creatorName nameType="Personal">Feldman, Heidi Li</creatorName>
+            <givenName>Heidi Li</givenName>
+            <familyName>Feldman</familyName>
+            <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0003-1905-2698</nameIdentifier>
+        </creator>
+    </creators>
+    <titles>
+        <title xml:lang="en">Science and Uncertainty in Mass Exposure Litigation</title>
+        <title xml:lang="en">Science and Uncertainty in Mass Exposure Litigation, 74 Tex. L. Rev. 1 (1995)</title>
+    </titles>
+    <publisher>Texas Law Review</publisher>
+    <publicationYear>1995</publicationYear>
+    <resourceType resourceTypeGeneral="JournalArticle">Article</resourceType>
+    <subjects>
+        <subject subjectScheme="Fields of Science and Technology (FOS)" schemeURI="http://www.oecd.org/science/inno/38235147.pdf" classificationCode="5.5">FOS: Law</subject>
+    </subjects>
+    <contributors>
+        <contributor contributorType="HostingInstitution">
+            <contributorName nameType="Organizational">Georgetown Law Library</contributorName>
+            <nameIdentifier nameIdentifierScheme="" schemeURI=""/>
+            <affiliation affiliationIdentifier="https://ror.org/05vzafd60" affiliationIdentifierScheme="ROR" schemeURI="https://ror.org">Georgetown University</affiliation>
+        </contributor>
+    </contributors>
+    <dates>
+        <date dateType="Issued">1995-11</date>
+        <date dateType="Collected">2016-04-25</date>
+    </dates>
+    <language>en</language>
+    <relatedIdentifiers>
+        <relatedIdentifier relatedIdentifierType="ISSN" relationType="IsPublishedIn" resourceTypeGeneral="Journal">0040-4411</relatedIdentifier>
+    </relatedIdentifiers>
+    <relatedItems>
+        <relatedItem relatedItemType="Journal" relationType="IsSourceOf">
+            <relatedItemIdentifier relatedItemIdentifierType="ISSN">0040-4411</relatedItemIdentifier>
+            <creators>
+                <creator>
+                    <creatorName>University of Texas School of Law</creatorName>
+                </creator>
+            </creators>
+            <titles>
+                <title>Texas Law Review</title>
+            </titles>
+            <publicationYear>1995</publicationYear>
+            <volume>74</volume>
+            <issue>1</issue>
+        </relatedItem>
+    </relatedItems>
+    <sizes/>
+    <formats>
+        <format>text/html</format>
+        <format>application/pdf</format>
+    </formats>
+    <version/>
+    <descriptions>
+        <description xml:lang="en" descriptionType="Abstract">Critics of the tort system have condemned courts for their alleged leniency in admitting scientific expert testimony, especially in mass exposure litigation. Claiming that this has resulted in an epidemic of "junk science" in the courtroom, these commentators have urged a more scientific approach to admissibility, intimating that employing more scientific standards would exclude scientific evidence favorable to plaintiffs, thereby demonstrating to factfinders that litigated substances are in fact safe or at least not unsafe.</description>
+    </descriptions>
+</resource>

--- a/spec/writers/citation_writer_spec.rb
+++ b/spec/writers/citation_writer_spec.rb
@@ -48,5 +48,14 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.locale).to eq("en-US")
       expect(subject.citation).to eq("Clark, D. (2019). <i>Exploring the \"Many analysts, one dataset\" project from COS</i>. Gigantum, Inc. https://doi.org/10.34747/g6yb-3412")
     end
+
+    it "journal article with container title" do
+      input = fixture_path + "datacite_journal_article.xml"
+      subject = Bolognese::Metadata.new(input: input, from: "datacite")
+      expect(subject.types["citeproc"]).to eq("article-journal")
+      expect(subject.style).to eq("apa")
+      expect(subject.locale).to eq("en-US")
+      expect(subject.citation).to eq('Feldman, H. L. (1995). Science and Uncertainty in Mass Exposure Litigation. <i>Texas Law Review</i>. https://doi.org/10.60843/5egy-vc42')
+    end
   end
 end


### PR DESCRIPTION
Fixes #182

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Fixes an issue where DOIs with citeproc type `article-journal` may render certain parts of a citation as a hash. 

closes: #182 

## Approach
<!--- _How does this change address the problem?_ -->

Makes a correction in `container_title` where `publisher` was retrieved as a hash and without getting the `name`. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
