### PR TITLE
Fix for ORCID and ROR identifiers ending with a `/` not being rendered in JSON when converting from XML

### DIFF
--- a/lib/bolognese/utils.rb
+++ b/lib/bolognese/utils.rb
@@ -600,12 +600,12 @@ module Bolognese
     end
 
     def validate_orcid(orcid)
-      orcid = Array(/\A(?:(?:http|https):\/\/(?:(?:www|sandbox)?\.)?orcid\.org\/)?(\d{4}[[:space:]-]\d{4}[[:space:]-]\d{4}[[:space:]-]\d{3}[0-9X]+)\z/.match(orcid)).last
+      orcid = Array(/\A(?:(?:http|https):\/\/(?:(?:www|sandbox)?\.)?orcid\.org\/)?(\d{4}[[:space:]-]\d{4}[[:space:]-]\d{4}[[:space:]-]\d{3}[0-9X]+)\/{0,1}\z/.match(orcid)).last
       orcid.gsub(/[[:space:]]/, "-") if orcid.present?
     end
 
     def validate_ror(ror)
-      Array(/^(?:(?:(?:http|https):\/\/)?ror\.org\/)?(0\w{6}\d{2})$/.match(ror)).last
+      Array(/^(?:(?:(?:http|https):\/\/)?ror\.org\/)?(0\w{6}\d{2})\/{0,1}$/.match(ror)).last
     end
 
     def validate_orcid_scheme(orcid_scheme)

--- a/spec/author_utils_spec.rb
+++ b/spec/author_utils_spec.rb
@@ -168,11 +168,12 @@ describe Bolognese::Metadata, vcr: true do
     expect(subject.creators[4]).to eq("nameType"=>"Organizational", "name"=>"University Of Kivu", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/01qfhxr31", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
     expect(subject.creators[5]).to eq("nameType"=>"Organizational", "name"=>"សាកលវិទ្យាល័យកម្ពុជា", "nameIdentifiers"=> [{"nameIdentifier"=>"http://ror.org/025e3rc84", "nameIdentifierScheme"=>"RORS"}], "affiliation"=>[])
     expect(subject.creators[6]).to eq("nameType"=>"Organizational", "name"=>"جامعة زاخۆ", "nameIdentifiers"=> [{"nameIdentifier"=>"05sd1pz50", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"RORS"}], "affiliation"=>[])
+    expect(subject.creators[9]).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
     expect(subject.contributors.first).to eq("nameType"=>"Organizational", "name"=>" Nawroz University ", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04gp75d48", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[], "contributorType"=>"Producer")
     expect(subject.contributors.last).to eq("nameType"=>"Organizational", "name"=>"University Of Greenland (Https://Www.Uni.Gl/)", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/00t5j6b61", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}],"affiliation"=>[], "contributorType"=>"Sponsor")
   end
 
-  context "affiliationIdentifier" do
+  context "affiliationIdentifier/nameIdentifier" do
     let(:input) { fixture_path + 'datacite-example-ROR-nameIdentifiers.xml' }
     subject { Bolognese::Metadata.new(input: input, from: "datacite") }
 
@@ -205,6 +206,11 @@ describe Bolognese::Metadata, vcr: true do
     it "should sanitize valid ORCID id/URL before normalization" do
       #"  0000-0001-9998-0118  ",  # Valid ORCID with leading/trailing spaces
       expect(subject.creators[8]["nameIdentifiers"]).to eq([{"nameIdentifier"=>"https://orcid.org/0000-0001-9998-0118", "schemeUri"=>"https://orcid.org", "nameIdentifierScheme"=>"ORCID"}])
+    end
+
+    it "should normalize valid ORCID nameIdentifier with trailing slash" do
+      #"  0000-0001-9998-0118  ",  # Valid ORCID with leading/trailing spaces
+      expect(subject.creators[10]["nameIdentifiers"]).to eq([{"nameIdentifier"=>"https://orcid.org/0000-0001-9998-0117", "schemeUri"=>"https://orcid.org", "nameIdentifierScheme"=>"ORCID"}])
     end
 
     it "should parse non ROR schema's without normalizing them" do

--- a/spec/fixtures/datacite-example-ROR-nameIdentifiers.xml
+++ b/spec/fixtures/datacite-example-ROR-nameIdentifiers.xml
@@ -43,6 +43,14 @@
             <creatorName nameType="Personal">Mike B</creatorName>
             <nameIdentifier nameIdentifierScheme="ORCID"> 0000-0001-9998-0118 </nameIdentifier>
         </creator>
+        <creator>
+            <creatorName nameType="Organizational">Gump South Pacific Research Station</creatorName>
+            <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org/">https://ror.org/04sk0et52/</nameIdentifier>
+        </creator>
+        <creator>
+            <creatorName nameType="Personal">Ashwini Sukale</creatorName>
+            <nameIdentifier schemeURI="https://orcid.org/" nameIdentifierScheme="ORCID">https://orcid.org/0000-0001-9998-0117/</nameIdentifier>
+        </creator>
     </creators>
     <titles>
         <title xml:lang="en-US">Genomic Standards Consortium (GSC) Island Sampling Day: Moorea Reef to Ridges Genomic Transect</title>


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Fix for ORCID and ROR identifiers ending with a `/` not being rendered in JSON when converting from XML.

closes: #188

## Approach
<!--- _How does this change address the problem?_ -->

Permits trailing slashes in `validate_orcid` and `validate_ror` methods.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
