### PR TITLE
Product-Backlog issue #309 - Using JSON SchemaOrg type appropriately …

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bolognese (2.3.2)
+    bolognese (2.3.3)
       activesupport (>= 4.2.5)
       benchmark_methods (~> 0.7)
       bibtex-ruby (>= 5.1.0)

--- a/lib/bolognese/datacite_utils.rb
+++ b/lib/bolognese/datacite_utils.rb
@@ -128,7 +128,7 @@ module Bolognese
     def insert_resource_type(xml)
       return xml unless types.is_a?(Hash) && (types["schemaOrg"].present? || types["resourceTypeGeneral"])
 
-      xml.resourceType(types["resourceType"] || types["schemaOrg"],
+      xml.resourceType(types["resourceType"],
         'resourceTypeGeneral' => types["resourceTypeGeneral"] || Metadata::SO_TO_DC_TRANSLATIONS[types["schemaOrg"]] || "Other")
     end
 

--- a/lib/bolognese/version.rb
+++ b/lib/bolognese/version.rb
@@ -1,3 +1,3 @@
 module Bolognese
-  VERSION = "2.3.2"
+  VERSION = "2.3.3"
 end


### PR DESCRIPTION
…in resourceType XML

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
Make sure that JSON type settings are translated appropriately to <resourceType /> xml.

closes: [309](https://github.com/datacite/product-backlog/issues/309)

## Approach
<!--- _How does this change address the problem?_ -->

I used Cody's suggestion to remove '|| types["schemaOrg"]' from the code in question (at the url in the previous comment). Works fine. Added a couple of tests.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
