### PR TITLE
Stop title-casing creators.name and contributors.name values when creating JSON from XML

### DIFF
--- a/lib/bolognese/author_utils.rb
+++ b/lib/bolognese/author_utils.rb
@@ -100,7 +100,7 @@ module Bolognese
 
       # titleize strings
       # remove non-standard space characters
-      author.my_titleize.gsub(/[[:space:]]/, ' ')
+      author.gsub(/[[:space:]]/, ' ')
     end
 
     def is_personal_name?(author)

--- a/lib/bolognese/version.rb
+++ b/lib/bolognese/version.rb
@@ -1,3 +1,3 @@
 module Bolognese
-  VERSION = "2.3.4"
+  VERSION = "2.3.5"
 end

--- a/spec/author_utils_spec.rb
+++ b/spec/author_utils_spec.rb
@@ -89,7 +89,7 @@ describe Bolognese::Metadata, vcr: true do
       subject = Bolognese::Metadata.new(input: input, from: "datacite")
       meta = Maremma.from_xml(subject.raw).fetch("resource", {})
       response = subject.get_authors(meta.dig("creators", "creator"))
-      expect(response).to eq([{"name" => "Enos, Ryan (Harvard University); Fowler, Anthony (University Of Chicago); Vavreck, Lynn (UCLA)", "nameIdentifiers" => [], "affiliation" => []}])
+      expect(response).to eq([{"name" => "Enos, Ryan (Harvard University); Fowler, Anthony (University of Chicago); Vavreck, Lynn (UCLA)", "nameIdentifiers" => [], "affiliation" => []}])
     end
 
     it "hyper-authorship" do
@@ -104,7 +104,7 @@ describe Bolognese::Metadata, vcr: true do
     it "is organization" do
       author = {"email"=>"info@ucop.edu", "creatorName"=> { "__content__" => "University of California, Santa Barbara", "nameType" => "Organizational" }, "role"=>{"namespace"=>"http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode", "roleCode"=>"copyrightHolder"} }
       response = subject.get_one_author(author)
-      expect(response).to eq("nameType"=>"Organizational", "name"=>"University Of California, Santa Barbara", "nameIdentifiers" => [], "affiliation" => [])
+      expect(response).to eq("nameType"=>"Organizational", "name"=>"University of California, Santa Barbara", "nameIdentifiers" => [], "affiliation" => [])
     end
 
     it "name with affiliation" do
@@ -164,13 +164,13 @@ describe Bolognese::Metadata, vcr: true do
     input = fixture_path + 'datacite-example-ROR-nameIdentifiers.xml'
     subject = Bolognese::Metadata.new(input: input, from: "datacite")
     expect(subject.creators[2]).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
-    expect(subject.creators[3]).to eq("nameType"=>"Organizational", "name"=>"University Of Vic", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/006zjws59", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
-    expect(subject.creators[4]).to eq("nameType"=>"Organizational", "name"=>"University Of Kivu", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/01qfhxr31", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
+    expect(subject.creators[3]).to eq("nameType"=>"Organizational", "name"=>"University of Vic", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/006zjws59", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
+    expect(subject.creators[4]).to eq("nameType"=>"Organizational", "name"=>"University of Kivu", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/01qfhxr31", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
     expect(subject.creators[5]).to eq("nameType"=>"Organizational", "name"=>"សាកលវិទ្យាល័យកម្ពុជា", "nameIdentifiers"=> [{"nameIdentifier"=>"http://ror.org/025e3rc84", "nameIdentifierScheme"=>"RORS"}], "affiliation"=>[])
     expect(subject.creators[6]).to eq("nameType"=>"Organizational", "name"=>"جامعة زاخۆ", "nameIdentifiers"=> [{"nameIdentifier"=>"05sd1pz50", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"RORS"}], "affiliation"=>[])
     expect(subject.creators[9]).to eq("nameType"=>"Organizational", "name"=>"Gump South Pacific Research Station", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04sk0et52", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[])
     expect(subject.contributors.first).to eq("nameType"=>"Organizational", "name"=>" Nawroz University ", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/04gp75d48", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}], "affiliation"=>[], "contributorType"=>"Producer")
-    expect(subject.contributors.last).to eq("nameType"=>"Organizational", "name"=>"University Of Greenland (Https://Www.Uni.Gl/)", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/00t5j6b61", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}],"affiliation"=>[], "contributorType"=>"Sponsor")
+    expect(subject.contributors.last).to eq("nameType"=>"Organizational", "name"=>"University of Greenland (https://www.uni.gl/)", "nameIdentifiers"=> [{"nameIdentifier"=>"https://ror.org/00t5j6b61", "schemeUri"=>"https://ror.org", "nameIdentifierScheme"=>"ROR"}],"affiliation"=>[], "contributorType"=>"Sponsor")
   end
 
   context "affiliationIdentifier/nameIdentifier" do

--- a/spec/readers/codemeta_reader_spec.rb
+++ b/spec/readers/codemeta_reader_spec.rb
@@ -67,7 +67,7 @@ describe Bolognese::Metadata, vcr: true do
             "nameIdentifierScheme"=>"ORCID",
             "schemeUri"=>"https://orcid.org"}],
         "nameType"=>"Personal"},
-       {"name"=>"University Of California, Santa Barbara",
+       {"name"=>"University of California, Santa Barbara",
         "nameType"=>"Organizational",
         "nameIdentifiers" => [], "affiliation" => []}])
       expect(subject.titles).to eq([{"title"=>"R Interface to the DataONE REST API"}])

--- a/spec/readers/datacite_reader_spec.rb
+++ b/spec/readers/datacite_reader_spec.rb
@@ -619,7 +619,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.valid?).to be true
       expect(subject.id).to eq("https://doi.org/10.7910/dvn/eqtqyo")
       expect(subject.types["schemaOrg"]).to eq("Dataset")
-      expect(subject.creators).to eq([{"name" => "Enos, Ryan (Harvard University); Fowler, Anthony (University Of Chicago); Vavreck, Lynn (UCLA)", "nameIdentifiers" => [], "affiliation" => []}])
+      expect(subject.creators).to eq([{"name" => "Enos, Ryan (Harvard University); Fowler, Anthony (University of Chicago); Vavreck, Lynn (UCLA)", "nameIdentifiers" => [], "affiliation" => []}])
     end
 
     it "author with scheme" do
@@ -935,7 +935,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.types["resourceType"]).to eq("Simulation Tool")
       expect(subject.types["resourceTypeGeneral"]).to eq("Software")
       expect(subject.creators.length).to eq(5)
-      expect(subject.creators.first).to eq("nameType"=>"Personal", "name"=>"PatiÃ±O, Carlos", "givenName"=>"Carlos", "familyName"=>"PatiÃ±O", "nameIdentifiers" => [], "affiliation" => [])
+      expect(subject.creators.first).to eq("nameType"=>"Personal", "name"=>"PatiÃ±o, Carlos", "givenName"=>"Carlos", "familyName"=>"PatiÃ±o", "nameIdentifiers" => [], "affiliation" => [])
       expect(subject.titles).to eq([{"title"=>"LAMMPS Data-File Generator"}])
       expect(subject.dates).to eq([{"date"=>"2018-07-18", "dateType"=>"Valid"}, {"date"=>"2018-07-18", "dateType"=>"Accepted"}, {"date"=>"2018", "dateType"=>"Issued"}])
       expect(subject.publication_year).to eq("2018")
@@ -1061,7 +1061,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.types["schemaOrg"]).to eq("Dataset")
       expect(subject.types["resourceType"]).to eq("Disclosure")
       expect(subject.types["resourceTypeGeneral"]).to eq("Dataset")
-      expect(subject.creators).to eq([{"name"=>"Anonymous", "nameIdentifiers" => [], "affiliation" => []}])
+      expect(subject.creators).to eq([{"name"=>"anonymous", "nameIdentifiers" => [], "affiliation" => []}])
       expect(subject.titles).to eq([{"title"=>"Messung der Bildunschaerfe in H.264-codierten Bildern und Videosequenzen"}])
       expect(subject.dates).to eq([{"date"=>"2017", "dateType"=>"Issued"}])
       expect(subject.publication_year).to eq("2017")
@@ -1085,9 +1085,9 @@ describe Bolognese::Metadata, vcr: true do
                                        "nameIdentifiers"=>
                                          [{"nameIdentifier"=>"https://orcid.org/0000-0002-0077-5338",
                                            "nameIdentifierScheme"=>"ORCID", "schemeUri"=>"https://orcid.org"}],
-                                     "name"=>"Van Der A, Ronald",
+                                     "name"=>"Van der A, Ronald",
                                      "givenName"=>"Ronald",
-                                     "familyName"=>"Van Der A",
+                                     "familyName"=>"Van der A",
                                      "affiliation"=>[{"name"=>"Royal Netherlands Meteorological Institute (KNMI)"}]},
                                     {"nameType"=>"Personal",
                                      "name"=>"Allaart, Marc",
@@ -1164,7 +1164,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.types["ris"]).to eq("RPRT")
       expect(subject.types["citeproc"]).to eq("article-journal")
       expect(subject.creators.length).to eq(5)
-      expect(subject.creators.first).to eq("nameType"=>"Personal", "name"=>"Patel, Lina", "givenName"=>"Lina", "familyName"=>"Patel", "nameIdentifiers" => [], "affiliation" => [])
+      expect(subject.creators.first).to eq("name"=>"lina patel", "nameIdentifiers" => [], "affiliation" => [])
       expect(subject.titles).to eq([{"title"=>"Referee report. For: Gates - add article keywords to the metatags [version 2; referees: 1 approved]"}])
       expect(subject.publication_year).to eq("2018")
       expect(subject.publisher).to eq({"name"=>"Gates Open Research"})
@@ -1381,7 +1381,7 @@ describe Bolognese::Metadata, vcr: true do
     expect(subject.types["resourceTypeGeneral"]).to eq("Dataset")
     expect(subject.types["ris"]).to eq("DATA")
     expect(subject.types["citeproc"]).to eq("dataset")
-    expect(subject.creators.first).to eq("familyName"=>"Den Heijer", "givenName"=>"C", "name"=>"Den Heijer, C", "nameType"=>"Personal", "nameIdentifiers" => [], "affiliation" => [])
+    expect(subject.creators.first).to eq("familyName"=>"den Heijer", "givenName"=>"C", "name"=>"den Heijer, C", "nameType"=>"Personal", "nameIdentifiers" => [], "affiliation" => [])
     expect(subject.titles).to eq([{"lang"=>"en", "title"=>"Meteo measurements at the Sand Motor"}])
     expect(subject.publication_year).to eq("2017")
     expect(subject.publisher).to eq({"name"=>"4TU.Centre for Research Data"})

--- a/spec/readers/schema_org_reader_spec.rb
+++ b/spec/readers/schema_org_reader_spec.rb
@@ -131,7 +131,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(subject.types).to eq("bibtex"=>"misc", "citeproc"=>"dataset", "resourceTypeGeneral"=>"Dataset", "ris"=>"DATA", "schemaOrg"=>"Dataset")
       expect(subject.titles).to eq([{"title"=>"Summary data ankylosing spondylitis GWAS"}])
       expect(subject.container).to eq("identifier"=>"https://dataverse.harvard.edu", "identifierType"=>"URL", "title"=>"Harvard Dataverse", "type"=>"DataRepository")
-      expect(subject.creators).to eq([{"name" => "International Genetics Of Ankylosing Spondylitis Consortium (IGAS)", "nameIdentifiers"=>[], "affiliation" => []}])
+      expect(subject.creators).to eq([{"name" => "International Genetics of Ankylosing Spondylitis Consortium (IGAS)", "nameIdentifiers"=>[], "affiliation" => []}])
       expect(subject.subjects).to eq([{"subject"=>"Medicine, Health and Life Sciences"},
         {"subject"=>"Genome-Wide Association Studies"},
         {"subject"=>"Ankylosing spondylitis"}])

--- a/spec/writers/citation_writer_spec.rb
+++ b/spec/writers/citation_writer_spec.rb
@@ -38,7 +38,7 @@ describe Bolognese::Metadata, vcr: true do
       subject = Bolognese::Metadata.new(input: input, from: "datacite")
       expect(subject.style).to eq("apa")
       expect(subject.locale).to eq("en-US")
-      expect(subject.citation).to eq("Lab For Exosphere And Near Space Environment Studies. (2019). <i>lenses-lab/LYAO_RT-2018JA026426: Original Release</i> (Version 1.0.0) [Computer software]. Zenodo. https://doi.org/10.5281/zenodo.2598836")
+      expect(subject.citation).to eq("Lab for Exosphere and Near Space Environment Studies. (2019). <i>lenses-lab/LYAO_RT-2018JA026426: Original Release</i> (Version 1.0.0) [Computer software]. Zenodo. https://doi.org/10.5281/zenodo.2598836")
     end
 
     it "interactive resource without dates" do

--- a/spec/writers/crosscite_writer_spec.rb
+++ b/spec/writers/crosscite_writer_spec.rb
@@ -67,7 +67,7 @@ describe Bolognese::Metadata, vcr: true do
       crosscite = JSON.parse(subject.crosscite)
       expect(crosscite["titles"]).to eq([{"title"=>"R Interface to the DataONE REST API"}])
       expect(crosscite["creators"].length).to eq(3)
-      expect(crosscite["creators"].last).to eq("nameType" => "Organizational", "name"=>"University Of California, Santa Barbara", "nameIdentifiers" => [], "affiliation" => [])
+      expect(crosscite["creators"].last).to eq("nameType" => "Organizational", "name"=>"University of California, Santa Barbara", "nameIdentifiers" => [], "affiliation" => [])
       expect(crosscite["version"]).to eq("2.0.0")
       expect(crosscite["publisher"]).to eq({"name"=>"https://cran.r-project.org"})
     end
@@ -78,7 +78,7 @@ describe Bolognese::Metadata, vcr: true do
       crosscite = JSON.parse(subject.crosscite)
       expect(crosscite["titles"]).to eq([{"title"=>"R Interface to the DataONE REST API"}])
       expect(crosscite["creators"].length).to eq(3)
-      expect(crosscite["creators"].last).to eq("nameType" => "Organizational", "name"=>"University Of California, Santa Barbara", "nameIdentifiers" => [], "affiliation" => [])
+      expect(crosscite["creators"].last).to eq("nameType" => "Organizational", "name"=>"University of California, Santa Barbara", "nameIdentifiers" => [], "affiliation" => [])
       expect(crosscite["version"]).to eq("2.0.0")
       expect(crosscite["publisher"]).to eq({"name"=>"https://cran.r-project.org"})
     end

--- a/spec/writers/datacite_writer_spec.rb
+++ b/spec/writers/datacite_writer_spec.rb
@@ -91,7 +91,7 @@ describe Bolognese::Metadata, vcr: true do
                                                          {"nameIdentifierScheme"=>"ORCID",
                                                           "schemeURI"=>"https://orcid.org",
                                                           "__content__"=>"https://orcid.org/0000-0002-2192-403X"}},
-                                                         {"creatorName"=>{"__content__"=>"University Of California, Santa Barbara", "nameType"=>"Organizational"}}])
+                                                         {"creatorName"=>{"__content__"=>"University of California, Santa Barbara", "nameType"=>"Organizational"}}])
       expect(datacite.fetch("version")).to eq("2.0.0")
       expect(datacite.dig("publisher")).to eq("https://cran.r-project.org")
     end
@@ -116,7 +116,7 @@ describe Bolognese::Metadata, vcr: true do
                                                          {"nameIdentifierScheme"=>"ORCID",
                                                           "schemeURI"=>"https://orcid.org",
                                                           "__content__"=>"https://orcid.org/0000-0002-2192-403X"}},
-                                                         {"creatorName"=>{"__content__"=>"University Of California, Santa Barbara", "nameType"=>"Organizational"}}])
+                                                         {"creatorName"=>{"__content__"=>"University of California, Santa Barbara", "nameType"=>"Organizational"}}])
       expect(datacite.fetch("version")).to eq("2.0.0")
       expect(datacite.dig("publisher")).to eq("https://cran.r-project.org")
     end

--- a/spec/writers/schema_org_writer_spec.rb
+++ b/spec/writers/schema_org_writer_spec.rb
@@ -94,7 +94,7 @@ describe Bolognese::Metadata, vcr: true do
                                      "@type"=>"Person",
                                      "@id"=>"https://orcid.org/0000-0002-2192-403X",
                                      "affiliation"=>{"@type"=>"Organization", "name"=>"NCEAS"}},
-                                    {"name"=>"University Of California, Santa Barbara", "@type"=>"Organization"}])
+                                    {"name"=>"University of California, Santa Barbara", "@type"=>"Organization"}])
       expect(json["version"]).to eq("2.0.0")
       expect(json["keywords"]).to eq("data sharing, data repository, DataONE")
     end
@@ -279,7 +279,7 @@ describe Bolognese::Metadata, vcr: true do
       expect(json["@id"]).to eq("https://doi.org/10.5072/example-polygon")
       expect(json["@type"]).to eq("Dataset")
       expect(json["name"]).to eq("Meteo measurements at the Sand Motor")
-      expect(json["author"]).to eq("@type"=>"Person", "familyName"=>"Den Heijer", "givenName"=>"C", "name"=>"C Den Heijer")
+      expect(json["author"]).to eq("@type"=>"Person", "familyName"=>"den Heijer", "givenName"=>"C", "name"=>"C den Heijer")
       expect(json["includedInDataCatalog"]).to be_nil
       expect(json["spatialCoverage"].dig("geo", "polygon").length).to eq(34)
       expect(json["spatialCoverage"].dig("geo", "polygon")[0].first).to eq(["4.1738852605822", "52.03913926329928"])


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: datacite/product-backlog#308, datacite/datacite#1356

## Approach
<!--- _How does this change address the problem?_ -->
Data is stored and indexed properly. Bolognese is the culprit. The problem is in bolognese datacite_reader: read_datacite (datacite_reader.rb)  => get_authors (author_utils.rb) => get_one_author => my_titelize.  This is the only place that calls my_titleize.  

The solution is not to call my_titleize.  

Additionally, there are many tests with minor errors because they are coded to expect the data in error.  Fix the tests.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
