### PR TITLE
`Array.wrap(descriptions)` in the case that it is a dictionary

### DIFF
--- a/lib/bolognese/utils.rb
+++ b/lib/bolognese/utils.rb
@@ -1430,7 +1430,7 @@ module Bolognese
 
     def abstract_description
       # Fetch the first description with descriptionType "Abstract"
-      descriptions&.find { |d| d["descriptionType"] == "Abstract" }
+      Array.wrap(descriptions)&.find { |d| d["descriptionType"] == "Abstract" }
     end
   end
 end

--- a/spec/writers/schema_org_writer_spec.rb
+++ b/spec/writers/schema_org_writer_spec.rb
@@ -414,5 +414,13 @@ describe Bolognese::Metadata, vcr: true do
         "2020-01-01"
       )      
     end
+
+    it "when descriptions is a dictionary" do
+      input = fixture_path + 'datacite-example-full-v4.6.xml'
+      subject = Bolognese::Metadata.new(input: input)
+      subject.descriptions = { "descriptionType" => "Abstract", "description" => "This is an abstract as a dictionary." }
+      json = JSON.parse(subject.schema_org)
+      expect(json.fetch("description")).to eq("This is an abstract as a dictionary.")
+    end
   end
 end


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

The JSON in the `descriptions` attribute can sometimes be stored as a dictionary rather than an array in the DataCite DB. This can cause errors when generating Schema.org (and potentially other metadata formats) from DataCite metadata because `def abstract_description` expects an array. This PR is a patch that `Array.wrap`s `descriptions` to avoid errors. 

closes: https://github.com/datacite/datacite/issues/2411

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
