### PR TITLE
Correct typo in NORMALIZED_LICENSES list for `by-nd/4.0`

### DIFF
--- a/lib/bolognese/utils.rb
+++ b/lib/bolognese/utils.rb
@@ -32,7 +32,7 @@ module Bolognese
       "https://creativecommons.org/licenses/by-nd/2.0" => "https://creativecommons.org/licenses/by-nd/2.0/legalcode",
       "https://creativecommons.org/licenses/by-nd/2.5" => "https://creativecommons.org/licenses/by-nd/2.5/legalcode",
       "https://creativecommons.org/licenses/by-nd/3.0" => "https://creativecommons.org/licenses/by-nd/3.0/legalcode",
-      "https://creativecommons.org/licenses/by-nd/4.0" => "https://creativecommons.org/licenses/by-nd/2.0/legalcode",
+      "https://creativecommons.org/licenses/by-nd/4.0" => "https://creativecommons.org/licenses/by-nd/4.0/legalcode",
       "https://creativecommons.org/licenses/by-sa/1.0" => "https://creativecommons.org/licenses/by-sa/1.0/legalcode",
       "https://creativecommons.org/licenses/by-sa/2.0" => "https://creativecommons.org/licenses/by-sa/2.0/legalcode",
       "https://creativecommons.org/licenses/by-sa/2.5" => "https://creativecommons.org/licenses/by-sa/2.5/legalcode",

--- a/spec/fixtures/datacite-by-nd-4.0.xml
+++ b/spec/fixtures/datacite-by-nd-4.0.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource
+    xmlns="http://datacite.org/schema/kernel-3"
+    xmlns:dspace="http://www.dspace.org/xmlns/dspace/dim"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://datacite.org/schema/kernel-3 http://schema.datacite.org/meta/kernel-3/metadata.xsd">
+    <identifier identifierType="DOI">10.26041/FHNW-7645</identifier>
+    <creators>
+        <creator>
+            <creatorName>Piñeiro, Esteban</creatorName>
+        </creator>
+        <creator>
+            <creatorName>Locher, Nora</creatorName>
+        </creator>
+        <creator>
+            <creatorName>Pasche, Nathalie</creatorName>
+        </creator>
+    </creators>
+    <titles>
+        <title>The art of soft power banishment. New insights into the Swiss deportation regime</title>
+    </titles>
+    <publisher>Taylor &amp; Francis</publisher>
+    <publicationYear>2021</publicationYear>
+    <subjects>
+        <subject subjectScheme="ddc">300 - Sozialwissenschaften, Soziologie, Anthropologie</subject>
+    </subjects>
+    <contributors>
+        <contributor contributorType="DataManager">
+            <contributorName>Fachhochschule Nordwestschweiz FHNW</contributorName>
+        </contributor>
+        <contributor contributorType="HostingInstitution">
+            <contributorName>Fachhochschule Nordwestschweiz FHNW</contributorName>
+        </contributor>
+    </contributors>
+    <dates>
+        <date dateType="Accepted">2024-01-19</date>
+        <date dateType="Available">2024-01-19</date>
+        <date dateType="Issued">2021</date>
+    </dates>
+    <language>de</language>
+    <resourceType resourceTypeGeneral="Other">01A - Beitrag in wissenschaftlicher Zeitschrift</resourceType>
+    <alternateIdentifiers>
+        <alternateIdentifier alternateIdentifierType="doi">10.1080/01419870.2021.1989010</alternateIdentifier>
+        <alternateIdentifier alternateIdentifierType="issn">0141-9870</alternateIdentifier>
+        <alternateIdentifier alternateIdentifierType="issn">1466-4356</alternateIdentifier>
+        <alternateIdentifier alternateIdentifierType="uri">https://irf.fhnw.ch/handle/11654/43705</alternateIdentifier>
+        <alternateIdentifier alternateIdentifierType="uri">https://doi.org/10.26041/fhnw-7645</alternateIdentifier>
+    </alternateIdentifiers>
+    <rightsList>
+        <rights rightsURI="https://creativecommons.org/licenses/by-nd/4.0/"/>
+    </rightsList>
+</resource>

--- a/spec/readers/datacite_reader_spec.rb
+++ b/spec/readers/datacite_reader_spec.rb
@@ -1849,5 +1849,17 @@ describe Bolognese::Metadata, vcr: true do
 
     end
   end
+
+  describe "DataCite with CC-BY-ND 4.0 rightsURI" do
+    it "returns correct normalized right" do
+      input = fixture_path + 'datacite-by-nd-4.0.xml'
+      subject = Bolognese::Metadata.new(input: input)
+      expect(subject.valid?).to be true
+
+      rights_list = subject.rights_list
+      right = rights_list.find { |r| r["rightsIdentifier"] == "cc-by-nd-4.0" }
+      expect(right).not_to be_nil
+    end
+  end
 end
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

The normalization for rights with rightsURI "https://creativecommons.org/licenses/by-nd/4.0" was incorrectly assigned to "https://creativecommons.org/licenses/by-nd/2.0/legalcode", resulting in CC-BY-ND 4.0 licenses appearing as CC-BY-ND 2.0 licenses in the REST API and other dependent services like Commons. 

closes: https://github.com/datacite/datacite/issues/2441

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

- [ ] We will need to re-import all DOIs with `cc-by-nd-4.0` rightsIdentifiers as they have been imported incorrectly from XML due to the existing behavior.

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
